### PR TITLE
Add interactive GUI (PySide6/VTK), .dmn IO, sphere refinement, and Mesa setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C/C++ artifacts from Cython builds
+*.so
+*.pyd
+*.dll
+*.dylib
+*.o
+*.a
+*.cpp
+
+# Build and packaging
+build/
+dist/
+*.egg-info/
+
+# Local caches and temp
+tmp/
+.idea/
+
+# Local binaries and downloads
+svv/bin/
+svZeroDSolver*
+
+# Sample artifacts
+cube.dmn

--- a/docs/algorithm.html
+++ b/docs/algorithm.html
@@ -35,7 +35,7 @@
         <a href="index.html#about">About</a>
         <a href="install.html">Installation</a>
         <a class="active" href="doc.html">Documentation</a>
-        <a href="#simulation">Simulation</a>
+        <a href="index.html#simulation">Simulation</a>
         <a href="https://pypi.org/project/svv/" target="_blank" rel="noopener">PyPI</a>
         <a href="https://github.com/SimVascular/svVascularize" target="_blank" rel="noopener">GitHub</a>
       </nav>

--- a/docs/api/domain.html
+++ b/docs/api/domain.html
@@ -18,7 +18,7 @@
                 <a href="../index.html#about">About</a>
                 <a href="../install.html">Installation</a>
                 <a href="../doc.html">Documentation</a>
-                <a href="#simulation">Simulation</a>
+                <a href="../index.html#simulation">Simulation</a>
                 <a href="https://pypi.org/project/svv/" target="_blank" rel="noopener">PyPI</a>
                 <a href="https://github.com/SimVascular/svVascularize" target="_blank" rel="noopener">GitHub</a>
             </nav>

--- a/docs/api/forest.html
+++ b/docs/api/forest.html
@@ -18,7 +18,7 @@
                 <a href="../index.html#about">About</a>
                 <a href="../install.html">Installation</a>
                 <a href="../doc.html">Documentation</a>
-                <a href="#simulation">Simulation</a>
+                <a href="../index.html#simulation">Simulation</a>
                 <a href="https://pypi.org/project/svv/" target="_blank" rel="noopener">PyPI</a>
                 <a href="https://github.com/SimVascular/svVascularize" target="_blank" rel="noopener">GitHub</a>
             </nav>

--- a/docs/api/index_api.html
+++ b/docs/api/index_api.html
@@ -18,7 +18,7 @@
                 <a href="../index.html#about">About</a>
                 <a href="../install.html">Installation</a>
                 <a href="../doc.html">Documentation</a>
-                <a href="#simulation">Simulation</a>
+                <a href="../index.html#simulation">Simulation</a>
                 <a href="https://pypi.org/project/svv/" target="_blank" rel="noopener">PyPI</a>
                 <a href="https://github.com/SimVascular/svVascularize" target="_blank" rel="noopener">GitHub</a>
             </nav>
@@ -386,6 +386,15 @@ forest.export_solid(outdir='forest_model')</code></pre>
                                     </ul>
                                 </div>
                             </div>
+                        </div>
+
+                        <div class="api-classes">
+                            <h4>Main Classes</h4>
+                            <ul class="api-class-list">
+                                <li>
+                                    <a href="simulation.html"><code>Simulation</code></a> - Container for generating meshes and simulation files
+                                </li>
+                            </ul>
                         </div>
 
                         <div class="api-example">

--- a/docs/api/patch.html
+++ b/docs/api/patch.html
@@ -18,7 +18,7 @@
                 <a href="../index.html#about">About</a>
                 <a href="../install.html">Installation</a>
                 <a href="../doc.html">Documentation</a>
-                <a href="#simulation">Simulation</a>
+                <a href="../index.html#simulation">Simulation</a>
                 <a href="https://pypi.org/project/svv/" target="_blank" rel="noopener">PyPI</a>
                 <a href="https://github.com/SimVascular/svVascularize" target="_blank" rel="noopener">GitHub</a>
             </nav>

--- a/docs/api/simulation.html
+++ b/docs/api/simulation.html
@@ -18,7 +18,7 @@
                 <a href="../index.html#about">About</a>
                 <a href="../install.html">Installation</a>
                 <a href="../doc.html">Documentation</a>
-                <a href="#simulation">Simulation</a>
+                <a href="../index.html#simulation">Simulation</a>
                 <a href="https://pypi.org/project/svv/" target="_blank" rel="noopener">PyPI</a>
                 <a href="https://github.com/SimVascular/svVascularize" target="_blank" rel="noopener">GitHub</a>
             </nav>

--- a/docs/api/tree.html
+++ b/docs/api/tree.html
@@ -18,7 +18,7 @@
                 <a href="../index.html#about">About</a>
                 <a href="../install.html">Installation</a>
                 <a href="../doc.html">Documentation</a>
-                <a href="#simulation">Simulation</a>
+                <a href="../index.html#simulation">Simulation</a>
                 <a href="https://pypi.org/project/svv/" target="_blank" rel="noopener">PyPI</a>
                 <a href="https://github.com/SimVascular/svVascularize" target="_blank" rel="noopener">GitHub</a>
             </nav>

--- a/docs/doc.html
+++ b/docs/doc.html
@@ -71,6 +71,20 @@
       <li><a href="https://github.com/SimVascular/svVascularize/issues" target="_blank" rel="noopener">GitHub Issues</a></li>
     </ul>
 
+    <h3 id="simulation">Simulation Overview</h3>
+    <p>The <code>Simulation</code> module mirrors the capabilities in the library today:</p>
+    <ul>
+      <li><a href="pipeline.html">3-D CFD pipeline</a> &mdash; full workflow from <code>build_meshes()</code> through
+        <code>write_3d_fluid_simulation()</code>, including boundary layer options and multi-tree exports.</li>
+      <li><a href="api/simulation.html">Simulation API reference</a> &mdash; method-by-method detail on mesh storage,
+        face extraction, and svFSI XML generation.</li>
+      <li><a href="quickstart.html#export-0d-simulation-files">0-D exports</a> &mdash; use
+        <code>svv.simulation.fluid.rom.zero_d</code> helpers for fast circuit models; 1-D parameter builders are also
+        included in <code>Simulation.construct_1d_fluid_simulation()</code> for multiscale coupling.</li>
+    </ul>
+    <div class="callout info"><strong>Tip:</strong> 0-D and 1-D solvers are shipped separately; see the installation
+      guide&rsquo;s <a href="install.html#simulation">simulation extras</a> for setup notes.</div>
+
   </main>
 
   <!-- Footer -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,6 +46,26 @@
   </section>
 
 
+  <section id="simulation" class="content">
+    <div class="container">
+      <h3>Simulation Workflows</h3>
+      <p>The <code>svv.simulation.Simulation</code> container turns generated trees and forests into ready-to-run
+        solver input. It automates mesh generation, boundary extraction, and svFSI configuration so you can move from a
+        synthetic network to a 3-D CFD job without leaving Python.</p>
+      <ul>
+        <li><strong>3D CFD:</strong> build watertight tet meshes, optional boundary layers, extract wall/outlet faces,
+          and emit svFSI XML plus surface/volume mesh files.</li>
+        <li><strong>Multi-tree support:</strong> forests are handled tree-by-tree, letting you select which networks to
+          mesh and export.</li>
+        <li><strong>Reduced-order:</strong> direct helpers in <code>svv.simulation.fluid.rom</code> export matching 0-D
+          circuits today, with 1-D parameter generation available for coupling work.</li>
+      </ul>
+      <div class="callout info"><strong>Need details?</strong> The <a href="pipeline.html">3-D pipeline</a> and <a href="api/simulation.html">Simulation API</a> pages walk through every step, from
+        <code>build_meshes()</code> to writing solver files.</div>
+    </div>
+  </section>
+
+
   <footer>
     <div class="container">
       <p>&copy; 2025 SimVascular, Stanford University, The Regents of the University of California, and others —

--- a/docs/install.html
+++ b/docs/install.html
@@ -47,7 +47,7 @@
       <pre data-copy><code class="language-shell">python -m pip install --upgrade pip  # upgrade installer
 python -m pip install svv</code></pre>
       <p>This installs the <em>core</em> pre-built synthetic vascular-generation wheel from PyPI.</p>
-      <div class="callout"><strong>Need hemodynamics solvers?</strong> They are not included by default—see <a href="#optional-solvers">Optional solvers</a>.</div>
+      <div class="callout"><strong>Need hemodynamics solvers?</strong> They are not included by default—see <a href="#simulation">Simulation extras</a>.</div>
     </section>
 
     <!-- REQUIREMENTS -->
@@ -152,11 +152,12 @@ python -m pip install -e .[dev]</code></pre>
     </section>
 
     <!-- SOLVERS -->
-    <section id="optional-solvers">
-      <h2>Optional Hemodynamic CFD / ROM solvers</h2>
-          <p>The <b>svVascularize</b> Python API is solver-agnostic. For
-     flow analysis you can link to the SimVascular solver
-     family shown in the table:</p>
+    <section id="simulation">
+      <h2>Simulation extras</h2>
+          <p>The <b>svVascularize</b> Python API is solver-agnostic. The
+     <code>Simulation</code> container prepares meshes and svFSI XML files, while helper functions in
+     <code>svv.simulation.fluid.rom</code> emit 0-D circuits. To actually march solutions forward you can link to the
+     SimVascular solvers below:</p>
 
   <table>
     <thead><tr>
@@ -177,6 +178,10 @@ python -m pip install -e .[dev]</code></pre>
           <td>CMake ≥ 3.20, VTK ≥ 9, MPI, BLAS, LAPACK</td></tr>
     </tbody>
   </table>
+        <div class="callout info"><strong>Tip:</strong> After calling <code>Simulation.construct_3d_fluid_simulation()</code>
+          use <code>Simulation.write_3d_fluid_simulation()</code> to emit meshes and <code>fluid_simulation_*.xml</code> files that
+          svFSI consumes directly. The ROM helpers write JSON/<code>.flow</code> data next to the geometry so you can drive
+          multiscale studies from the same tree.</div>
           <!-- 0-D install -->
   <h3 id="solver-0d"><code>svZeroDSolver</code></h3>
   <p>Pre-built wheels do not yet exist for this solver;

--- a/docs/pipeline.html
+++ b/docs/pipeline.html
@@ -69,6 +69,33 @@
          These, as well as surface mesh unioning operations, are non-trivial and may take minutes-hours to complete.
          Users can supply custom meshing parameters for their applications to override default values this may result
          in more efficient meshing, but it is recommended that default parameters are attemped first.</div>
+     <p>Once meshes exist, identify wall and outlet patches that become boundary conditions. The
+         <code>Simulation.extract_faces()</code> routine wraps <code>svv.simulation.utils.extract_faces</code> to label
+         surfaces on both the solid model and the tetrahedral mesh.</p>
+     <pre data-copy> <code class="language-python"># Detect walls, outlets, and shared boundaries
+sim.extract_faces(crease_angle=60.0)
+
+# Inspect names stored in the GeneralMesh container
+print(sim.fluid_domain_meshes[0].faces.keys())</code></pre>
+     <p>Finally, assemble the svFSI configuration and write everything to disk. The default output directory is created if
+         it does not exist.</p>
+     <pre data-copy> <code class="language-python"># Build and persist 3-D CFD input files
+sim.construct_3d_fluid_simulation()
+sim.write_3d_fluid_simulation()
+
+# Result: meshes + XML under sim.file_path (e.g. ./simulations/example/)</code></pre>
+     <div class="callout info"><strong>Directory layout:</strong> The export creates a <code>mesh/</code> folder containing
+         the volume grid (<code>.vtu</code> or <code>.vtp</code>), a <code>mesh-surfaces/</code> folder for each named face, and
+         a <code>fluid_simulation_0-0.xml</code> svFSI input file.</div>
+     <p>For rapid prototyping, couple the same tree to the reduced-order solvers shipped with SimVascular.</p>
+     <pre data-copy> <code class="language-python">from svv.simulation.fluid.rom.zero_d.zerod_tree import export_0d_simulation
+
+export_0d_simulation(t, outdir=sim.file_path + "/rom_0d")
+
+# Optionally stage 1-D parameters for multi-scale workflows
+sim.construct_1d_fluid_simulation(time_step_size=1e-3, number_time_steps=2000)</code></pre>
+     <div class="callout warning"><strong>Note:</strong> Writing of 1-D files is not yet automated. The parameter bundle
+         returned by <code>construct_1d_fluid_simulation()</code> can be passed to the SimVascular 1-D solver tools.</div>
  </main>
   <footer>
     <div class="container">

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -55,7 +55,7 @@ t.show(plot_domain=True)</code></pre>
       <img src="graphics/quickstart_orbit.gif" alt="Orbit around vascular tree" width="300" />
       <figcaption> Rotating view of the generated vascular tree </figcaption>
     </figure>
-    <h3>Export 0‑D simulation files</h3>
+    <h3 id="export-0d-simulation-files">Export 0‑D simulation files</h3>
     <pre data-copy><code class="language-python">from svv.simulation.fluid.rom.zero_d.zerod_tree import export_0d_simulation
 
 export_0d_simulation(t, outdir="my_tree_0d")
@@ -105,7 +105,7 @@ f.connections.tree_connections[0].show().show()</code></pre>
       <img src="graphics/quickstart_forest_connected_orbit.gif" alt="Orbit around connected vascular forest" width="400" />
       <figcaption> Rotating view of the connected vascular forest </figcaption>
     </figure>
-  <h3>Export 0-D simulation files</h3>
+  <h3 id="export-0d-forest">Export 0-D simulation files</h3>
       <p>Because a forest object may contain multiple fluid networks, it is important to specify which network a user wants
       to export for simulation as well as the inlet boundaries. These are the second and thrid positional arguments of the
       simulation exporting function, respectively. </p>

--- a/install_mesa.sh
+++ b/install_mesa.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Install Mesa drivers for software rendering in conda environment
+
+echo "Installing Mesa drivers for software rendering..."
+
+if ! command -v conda &> /dev/null; then
+    echo "Error: conda not found. Please ensure conda is installed and activated."
+    exit 1
+fi
+
+if [ -z "$CONDA_PREFIX" ]; then
+    echo "Error: No conda environment activated. Please activate a conda environment first."
+    exit 1
+fi
+
+echo "Installing Mesa packages in conda environment: $CONDA_PREFIX"
+
+# Install Mesa packages (double-check libffi and mesa compatibility)
+conda install -y -c conda-forge \
+    mesa-libgl-cos7-x86_64 \
+    mesa-dri-drivers-cos7-x86_64 \
+    mesalib \
+    libglu \
+    libffi
+
+# Alternative: Install newer mesa packages if available
+conda install -y -c conda-forge mesa-libgl-devel-cos7-x86_64 2>/dev/null || true
+
+echo ""
+echo "Mesa installation complete. Checking for drivers..."
+
+# Check if drivers are installed
+DRI_LOCATIONS=(
+    "$CONDA_PREFIX/lib/dri"
+    "$CONDA_PREFIX/x86_64-conda-linux-gnu/sysroot/usr/lib64/dri"
+    "$CONDA_PREFIX/x86_64-conda-linux-gnu/sysroot/usr/lib/dri"
+)
+
+FOUND=0
+for dir in "${DRI_LOCATIONS[@]}"; do
+    if [ -d "$dir" ]; then
+        echo "Found DRI directory: $dir"
+        ls -la "$dir"/*swrast* "$dir"/*llvmpipe* 2>/dev/null && FOUND=1
+    fi
+done
+
+if [ "$FOUND" -eq 1 ]; then
+    echo ""
+    echo "Success! Mesa drivers installed successfully."
+    echo "You can now run: ./launch_gui.sh"
+else
+    echo ""
+    echo "Warning: Could not verify Mesa driver installation."
+    echo "Try running: ./launch_gui.sh --debug-gl for more information"
+fi

--- a/launch_gui.sh
+++ b/launch_gui.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Launcher script for svVascularize GUI with software rendering
+
+# Set environment for software rendering
+export LIBGL_ALWAYS_SOFTWARE=1
+export GALLIUM_DRIVER=llvmpipe
+export MESA_GL_VERSION_OVERRIDE=3.3
+
+# Set DRI driver path to conda's Mesa drivers
+if [ -n "$CONDA_PREFIX" ]; then
+    export LIBGL_DRIVERS_PATH="$CONDA_PREFIX/x86_64-conda-linux-gnu/sysroot/usr/lib64/dri"
+fi
+
+# Add svVascularize to Python path
+export PYTHONPATH="$(pwd):$PYTHONPATH"
+
+# Launch the GUI
+python -c "
+import sys
+from qtpy.QtWidgets import QApplication
+from svv.visualize.gui import VascularizeGUI
+
+app = QApplication(sys.argv)
+gui = VascularizeGUI()
+gui.show()
+sys.exit(app.exec_())
+"

--- a/launch_gui.sh
+++ b/launch_gui.sh
@@ -1,23 +1,160 @@
 #!/bin/bash
 # Launcher script for svVascularize GUI with software rendering
 
-# Set environment for software rendering
-export LIBGL_ALWAYS_SOFTWARE=1
-export GALLIUM_DRIVER=llvmpipe
-export MESA_GL_VERSION_OVERRIDE=3.3
-
-# Set DRI driver path to conda's Mesa drivers
-if [ -n "$CONDA_PREFIX" ]; then
-    export LIBGL_DRIVERS_PATH="$CONDA_PREFIX/x86_64-conda-linux-gnu/sysroot/usr/lib64/dri"
-fi
-
 # Add svVascularize to Python path
 export PYTHONPATH="$(pwd):$PYTHONPATH"
 
+# Function to find Mesa drivers
+find_mesa_drivers() {
+    local candidates=()
+
+    # Check conda environment locations
+    if [ -n "$CONDA_PREFIX" ]; then
+        candidates+=(
+            "$CONDA_PREFIX/lib/dri"
+            "$CONDA_PREFIX/x86_64-conda-linux-gnu/sysroot/usr/lib64/dri"
+            "$CONDA_PREFIX/x86_64-conda-linux-gnu/sysroot/usr/lib/dri"
+        )
+
+        # Check base conda if in an environment
+        if [[ "$CONDA_PREFIX" == */envs/* ]]; then
+            BASE_PREFIX="${CONDA_PREFIX%/envs/*}"
+            candidates+=(
+                "$BASE_PREFIX/x86_64-conda-linux-gnu/sysroot/usr/lib64/dri"
+            )
+        fi
+    fi
+
+    # Check system locations (prioritize these as they exist)
+    candidates=(
+        "/usr/lib/x86_64-linux-gnu/dri"
+        "/usr/lib64/dri"
+        "/usr/lib/dri"
+        "${candidates[@]}"
+    )
+
+    # Find first existing directory
+    for dir in "${candidates[@]}"; do
+        if [ -d "$dir" ] && [ -f "$dir/swrast_dri.so" -o -f "$dir/llvmpipe_dri.so" ]; then
+            echo "$dir"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+# Parse command line arguments
+USE_SYSTEM_GL=0
+DEBUG_GL=0
+for arg in "$@"; do
+    case $arg in
+        --system-gl)
+            USE_SYSTEM_GL=1
+            shift
+            ;;
+        --debug-gl)
+            DEBUG_GL=1
+            shift
+            ;;
+        --help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --system-gl    Use system OpenGL instead of software rendering"
+            echo "  --debug-gl     Enable OpenGL debugging output"
+            echo "  --help         Show this help message"
+            echo ""
+            echo "Environment variables:"
+            echo "  SVV_GUI_GL_MODE='system'         Use system OpenGL (same as --system-gl)"
+            echo "  SVV_GUI_SOFTWARE_DRIVER='swr'    Use OpenSWR instead of llvmpipe"
+            echo "  SVV_LIBGL_DRIVERS_PATH='/path'   Override DRI drivers path"
+            exit 0
+            ;;
+    esac
+done
+
+# Configure OpenGL settings
+if [ "$USE_SYSTEM_GL" -eq 1 ]; then
+    export SVV_GUI_GL_MODE=system
+    echo "Using system OpenGL drivers"
+else
+    # Configure software rendering
+    export LIBGL_ALWAYS_SOFTWARE=1
+    export GALLIUM_DRIVER=llvmpipe
+    export MESA_GL_VERSION_OVERRIDE=3.3
+    export MESA_LOADER_DRIVER_OVERRIDE=llvmpipe
+    export QT_OPENGL=software
+    export SVV_GUI_GL_MODE=software
+
+    # Find and set Mesa drivers path
+    if [ -z "$SVV_LIBGL_DRIVERS_PATH" ]; then
+        DRI_PATH=$(find_mesa_drivers)
+        if [ $? -eq 0 ]; then
+            export LIBGL_DRIVERS_PATH="$DRI_PATH"
+            export SVV_LIBGL_DRIVERS_PATH="$DRI_PATH"
+            echo "Found Mesa drivers at: $DRI_PATH"
+        else
+            echo "Warning: Could not find Mesa DRI drivers. Trying system fallback..."
+            # Try installing mesa packages if needed
+            if command -v conda &> /dev/null && [ -n "$CONDA_PREFIX" ]; then
+                echo "Attempting to install Mesa drivers via conda..."
+                conda install -y -c conda-forge mesa-libgl-cos7-x86_64 mesa-dri-drivers-cos7-x86_64 2>/dev/null || true
+
+                # Try to find again after installation
+                DRI_PATH=$(find_mesa_drivers)
+                if [ $? -eq 0 ]; then
+                    export LIBGL_DRIVERS_PATH="$DRI_PATH"
+                    export SVV_LIBGL_DRIVERS_PATH="$DRI_PATH"
+                    echo "Mesa drivers installed and found at: $DRI_PATH"
+                fi
+            fi
+        fi
+    else
+        export LIBGL_DRIVERS_PATH="$SVV_LIBGL_DRIVERS_PATH"
+        echo "Using user-specified Mesa drivers at: $SVV_LIBGL_DRIVERS_PATH"
+    fi
+
+    # Force XCB on Wayland systems
+    if [ -n "$WAYLAND_DISPLAY" ]; then
+        export QT_QPA_PLATFORM=xcb
+    fi
+fi
+
+# Enable debugging if requested
+if [ "$DEBUG_GL" -eq 1 ]; then
+    export SVV_GUI_DEBUG_GL=1
+    export MESA_DEBUG=1
+    export LIBGL_DEBUG=verbose
+fi
+
+# Fix libffi conflicts for Mesa drivers
+if [ -n "$CONDA_PREFIX" ]; then
+    # Look for libffi in conda environment
+    if [ -f "$CONDA_PREFIX/lib/libffi.so.7" ]; then
+        export LD_PRELOAD="$CONDA_PREFIX/lib/libffi.so.7:$LD_PRELOAD"
+        echo "Using libffi from conda: $CONDA_PREFIX/lib/libffi.so.7"
+    elif [ -f "$CONDA_PREFIX/lib/libffi.so.8" ]; then
+        export LD_PRELOAD="$CONDA_PREFIX/lib/libffi.so.8:$LD_PRELOAD"
+        echo "Using libffi from conda: $CONDA_PREFIX/lib/libffi.so.8"
+    fi
+fi
+
 # Launch the GUI
+echo "Launching svVascularize GUI..."
 python -c "
 import sys
-from qtpy.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication
+from svv.visualize.gui import VascularizeGUI
+
+app = QApplication(sys.argv)
+gui = VascularizeGUI()
+gui.show()
+sys.exit(app.exec())
+" || python -c "
+# Fallback with exec_ for older PySide6
+import sys
+from PySide6.QtWidgets import QApplication
 from svv.visualize.gui import VascularizeGUI
 
 app = QApplication(sys.argv)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ scikit-learn
 tqdm
 pymeshfix==0.17.0
 numexpr
+pyvistaqt
+pyside6

--- a/svv/domain/domain.py
+++ b/svv/domain/domain.py
@@ -554,7 +554,7 @@ class Domain(object):
             self.area = _mesh.area
             self.volume = 0.0
         elif self.points.shape[1] == 3:
-            _mesh, nodes, vertices = tetrahedralize(self.boundary, verbose=verbose, **kwargs)
+            _mesh, nodes, vertices = tetrahedralize(self.boundary, order=1, nobisect=True, verbose=verbose, **kwargs)
             _mesh = _mesh.compute_cell_sizes()
             _mesh.cell_data['Normalized_Volume'] = (_mesh.cell_data['Volume'] / sum(_mesh.cell_data['Volume']))
             self.all_mesh_cells = list(range(_mesh.n_cells))

--- a/svv/domain/io/dmn.py
+++ b/svv/domain/io/dmn.py
@@ -1,0 +1,341 @@
+import os
+import json
+from typing import Optional
+
+import numpy as np
+from scipy.spatial import cKDTree
+
+try:
+    import pyvista as pv  # Optional for boundary/mesh restore
+except Exception:  # pragma: no cover
+    pv = None
+
+
+DMN_FORMAT = "svv.domain/1.0"
+
+
+def _ensure_ext(path: str) -> str:
+    if not path.lower().endswith(".dmn"):
+        return path + ".dmn"
+    return path
+
+
+def _compute_firsts_from_pts(PTS: np.ndarray) -> np.ndarray:
+    """
+    Derive representative points ("firsts") for each patch from padded PTS.
+    PTS shape: (n_patches, max_pts, 1, 1, 1, d)
+    """
+    n_patches = PTS.shape[0]
+    d = PTS.shape[-1]
+    firsts = np.zeros((n_patches, d), dtype=float)
+    for i in range(n_patches):
+        pts_i = PTS[i, :, 0, 0, 0, :]
+        mask = np.any(~np.isnan(pts_i), axis=1)
+        if not np.any(mask):
+            # Fallback to zeros if empty row (should not happen for solved domains)
+            firsts[i] = np.zeros((d,), dtype=float)
+        else:
+            firsts[i] = pts_i[np.argmax(mask)]
+    return firsts
+
+
+def write_dmn(domain, path: str, include_boundary: bool = False, include_mesh: bool = False,
+              include_patch_normals: bool = True) -> None:
+    """
+    Serialize a Domain instance into a .dmn file.
+
+    The .dmn container is a compressed NumPy archive written with a .dmn
+    extension. It stores the precomputed arrays required for fast evaluation
+    and enough metadata to rebuild the Domain state on load.
+
+    Parameters
+    ----------
+    domain : svv.domain.domain.Domain
+        The Domain to serialize. Must have been created/solved/built so that
+        A/B/C/D/PTS arrays exist and a function_tree is available.
+    path : str
+        Output filename. If no ".dmn" extension is provided, it will be added.
+    include_boundary : bool, optional
+        Include boundary (points + faces or lines) to restore visualization
+        without recomputing. Requires pyvista at load time. Default False.
+    include_mesh : bool, optional
+        Include interior mesh (nodes + connectivity) to restore interior sampling
+        and mesh metrics without recomputing. Requires pyvista (and BallTree) at
+        load time. Default False.
+    include_patch_normals : bool, optional
+        Include per‑patch normals (when available) padded to the same shape as
+        PTS. This enables full Patch reconstruction on load and subsequent calls
+        to Domain.build() to follow the standard workflow. Default True.
+
+    Notes
+    -----
+    - The writer validates that the Domain has the fast‑eval arrays and a
+      function_tree. If missing, call `domain.solve(...); domain.build(...)`
+      before saving.
+    - The container also stores representative patch points ("firsts") used to
+      rebuild the cKDTree on load.
+    """
+    # Validate prerequisites
+    if not hasattr(domain, "A") or not hasattr(domain, "B") or not hasattr(domain, "C") \
+            or not hasattr(domain, "D") or not hasattr(domain, "PTS"):
+        raise ValueError("Domain is not solved. Call domain.solve() before saving.")
+    if domain.function_tree is None:
+        raise ValueError("Domain.function_tree is not initialized. Call domain.solve() before saving.")
+
+    out_path = _ensure_ext(path)
+
+    # Core arrays for fast evaluation
+    A = np.asarray(domain.A)
+    B = np.asarray(domain.B)
+    C = np.asarray(domain.C)
+    D = np.asarray(domain.D)
+    PTS = np.asarray(domain.PTS)
+
+    # Representative points to rebuild the function k-d tree
+    firsts = _compute_firsts_from_pts(PTS)
+
+    # Base metadata
+    meta = {
+        "format": DMN_FORMAT,
+        "dims": int(domain.points.shape[1]),
+        "has_normals": bool(domain.normals is not None),
+        "random_seed": None if domain.random_seed is None else int(domain.random_seed),
+        "characteristic_length": None if domain.characteristic_length is None else float(domain.characteristic_length),
+        "convexity": None if domain.convexity is None else float(domain.convexity),
+        "has_patch_normals": False,
+    }
+    meta_json = json.dumps(meta)
+
+
+    arrays = {
+        "__meta__": np.frombuffer(meta_json.encode("utf-8"), dtype=np.uint8),
+        "points": np.asarray(domain.points, dtype=np.float64),
+        "normals": np.asarray(domain.normals, dtype=np.float64) if domain.normals is not None else np.empty((0, 0)),
+        "A": A,
+        "B": B,
+        "C": C,
+        "D": D,
+        "PTS": PTS,
+        "firsts": firsts,
+    }
+
+    # Optional: per-patch normals padded like PTS
+    if include_patch_normals:
+        patch_normals = []
+        have_any = False
+        # Prefer normals attached to built functions
+        funcs = getattr(domain, 'functions', None)
+        if funcs is not None and len(funcs) == A.shape[0]:
+            for i, f in enumerate(funcs):
+                nrm = getattr(f, 'normals', None)
+                if isinstance(nrm, np.ndarray) and nrm.ndim == 2 and nrm.shape[1] == domain.points.shape[1]:
+                    have_any = True
+                    patch_normals.append(nrm)
+                else:
+                    patch_normals.append(None)
+        else:
+            # Fall back to patch objects if available
+            patches = getattr(domain, 'patches', None)
+            if patches is not None and len(patches) == A.shape[0]:
+                for p in patches:
+                    nrm = getattr(p, 'normals', None)
+                    if isinstance(nrm, np.ndarray) and nrm.ndim == 2 and nrm.shape[1] == domain.points.shape[1]:
+                        have_any = True
+                        patch_normals.append(nrm)
+                    else:
+                        patch_normals.append(None)
+        if have_any and len(patch_normals) == A.shape[0]:
+            max_pts = PTS.shape[1]
+            d = domain.points.shape[1]
+            PNORMALS = np.full((A.shape[0], max_pts, 1, 1, 1, d), np.nan, dtype=np.float64)
+            for i in range(A.shape[0]):
+                if isinstance(patch_normals[i], np.ndarray):
+                    n_i = min(max_pts, patch_normals[i].shape[0])
+                    PNORMALS[i, :n_i, 0, 0, 0, :] = patch_normals[i][:n_i, :]
+            arrays["PNORMALS"] = PNORMALS
+            meta["has_patch_normals"] = True
+            meta_json = json.dumps(meta)
+            arrays["__meta__"] = np.frombuffer(meta_json.encode("utf-8"), dtype=np.uint8)
+
+    # Optional boundary
+    if include_boundary and getattr(domain, "boundary", None) is not None:
+        if pv is None:
+            raise RuntimeError("pyvista is required to save boundary data. Install pyvista or disable include_boundary.")
+        arrays["boundary_points"] = np.asarray(domain.boundary.points, dtype=np.float64)
+        # Save both faces and lines; one will be empty depending on dimension
+        faces = getattr(domain.boundary, "faces", None)
+        lines = getattr(domain.boundary, "lines", None)
+        arrays["boundary_faces"] = np.asarray(faces, dtype=np.int64) if faces is not None else np.empty((0,), dtype=np.int64)
+        arrays["boundary_lines"] = np.asarray(lines, dtype=np.int64) if lines is not None else np.empty((0,), dtype=np.int64)
+
+    # Optional interior mesh (nodes + connectivity) and quick stats
+    if include_mesh and getattr(domain, "mesh", None) is not None:
+        if pv is None:
+            raise RuntimeError("pyvista is required to save mesh data. Install pyvista or disable include_mesh.")
+        arrays["mesh_nodes"] = np.asarray(domain.mesh_nodes, dtype=np.float64)
+        arrays["mesh_vertices"] = np.asarray(domain.mesh_vertices, dtype=np.int64)
+        arrays["mesh_dim"] = np.array([domain.points.shape[1]], dtype=np.int64)
+
+    # Use a file handle to avoid NumPy forcing a .npz extension
+    with open(out_path, "wb") as fh:
+        np.savez_compressed(fh, **arrays)
+
+
+def read_dmn(path: str):
+    """
+    Deserialize a Domain from a .dmn file.
+
+    Returns a ready‑to‑use Domain with fast evaluation path initialized, and
+    reconstructs Patch objects (including normals, when stored) so that
+    Domain.build() can be invoked to derive boundary/mesh artifacts.
+
+    Parameters
+    ----------
+    path : str
+        The input .dmn file.
+
+    Returns
+    -------
+    Domain
+        A Domain instance with points, normals (if any), precomputed fast‑eval
+        arrays, function_tree, and reconstructed patches. If boundary/mesh were
+        saved, they are also restored.
+    """
+    from svv.domain.domain import Domain
+    from svv.domain.patch import Patch
+
+    file_path = _ensure_ext(path)
+    data = np.load(file_path, allow_pickle=False)
+
+    # Parse metadata
+    if "__meta__" not in data:
+        raise ValueError("Invalid .dmn file: missing metadata.")
+    meta_json = bytes(data["__meta__"].tolist()).decode("utf-8")
+    meta = json.loads(meta_json)
+    if not isinstance(meta, dict) or meta.get("format") != DMN_FORMAT:
+        raise ValueError("Unsupported .dmn format or version.")
+
+    # Create bare Domain and assign core arrays
+    points = np.asarray(data["points"], dtype=np.float64)
+    normals = data.get("normals")
+    if normals is not None and normals.size == 0:
+        normals = None
+    else:
+        normals = np.asarray(normals, dtype=np.float64)
+
+    dom = Domain(points, normals) if normals is not None else Domain(points)
+
+    # Attach fast-eval arrays
+    dom.A = np.asarray(data["A"])  # (n_patches, max_a, 1, 1, 1)
+    dom.B = np.asarray(data["B"])  # (n_patches, max_b, 1, 1, 1, d)
+    dom.C = np.asarray(data["C"])  # (n_patches, 1, 1, 1, d)
+    dom.D = np.asarray(data["D"])  # (n_patches, 1, 1, 1)
+    dom.PTS = np.asarray(data["PTS"])  # (n_patches, max_pts, 1, 1, 1, d)
+
+    # Rebuild function k-d tree from representative points
+    firsts = np.asarray(data["firsts"], dtype=np.float64)
+    dom.function_tree = cKDTree(firsts)
+
+    # Restore meta
+    dom.random_seed = meta.get("random_seed", None)
+    if dom.random_seed is not None:
+        dom.set_random_generator()
+    dom.characteristic_length = meta.get("characteristic_length", None)
+    dom.convexity = meta.get("convexity", None)
+
+    # Reconstruct patches from stored PTS (and patch normals if available) and parameter arrays so that callers
+    # can invoke Domain.build() again if desired.
+    try:
+        n_patches = dom.PTS.shape[0]
+        dom.patches = []
+        d = points.shape[1]
+        for i in range(n_patches):
+            pts_i = dom.PTS[i, :, 0, 0, 0, :]
+            valid_mask = np.any(~np.isnan(pts_i), axis=1)
+            n_i = int(valid_mask.sum())
+            if n_i == 0:
+                continue
+            pts_trim = pts_i[valid_mask]
+            # Per-patch normals if present
+            norms_trim = None
+            if "PNORMALS" in data:
+                pn_i = np.asarray(data["PNORMALS"][i, :, 0, 0, 0, :], dtype=np.float64)
+                valid_n = np.any(~np.isnan(pn_i), axis=1)
+                if int(valid_n.sum()) >= n_i:
+                    norms_trim = pn_i[valid_n][:n_i]
+            # Build constants for this patch from A/B/C/D
+            a_i = dom.A[i, :n_i, 0, 0, 0]
+            b_i = dom.B[i, :n_i, 0, 0, 0, :]
+            c_i = dom.C[i, 0, 0, 0, :]
+            d_i = float(dom.D[i, 0, 0, 0])
+            constants = np.concatenate([a_i, b_i.reshape(-1), c_i.reshape(-1), np.array([d_i])])
+            p = Patch()
+            if norms_trim is not None:
+                p.set_data(pts_trim, norms_trim, create_kernel=False)
+            else:
+                p.set_data(pts_trim, create_kernel=False)
+            p.constants = constants
+            dom.patches.append(p)
+    except Exception:
+        # If anything goes wrong, leave patches absent; evaluation still works.
+        dom.patches = []
+
+    # Optional: boundary
+    if "boundary_points" in data and pv is not None:
+        b_pts = np.asarray(data["boundary_points"], dtype=np.float64)
+        b_faces = np.asarray(data.get("boundary_faces", np.empty((0,), dtype=np.int64)))
+        b_lines = np.asarray(data.get("boundary_lines", np.empty((0,), dtype=np.int64)))
+        if b_faces.size > 0:
+            dom.boundary = pv.PolyData(b_pts, b_faces)
+        elif b_lines.size > 0:
+            dom.boundary = pv.PolyData(b_pts, lines=b_lines)
+        else:
+            dom.boundary = pv.PolyData(b_pts)
+        dom.boundary = dom.boundary.compute_cell_sizes()
+        if points.shape[1] == 2:
+            dom.boundary_nodes = dom.boundary.points.astype(np.float64)
+            dom.boundary_vertices = dom.boundary.lines.reshape(-1, 3)[:, 1:].astype(np.int64)
+        elif points.shape[1] == 3:
+            dom.boundary_nodes = dom.boundary.points.astype(np.float64)
+            dom.boundary_vertices = dom.boundary.faces.reshape(-1, 4)[:, 1:].astype(np.int64)
+
+    # Optional: interior mesh
+    if "mesh_nodes" in data and pv is not None:
+        m_nodes = np.asarray(data["mesh_nodes"], dtype=np.float64)
+        m_verts = np.asarray(data["mesh_vertices"], dtype=np.int64)
+        dom.mesh_nodes = m_nodes
+        dom.mesh_vertices = m_verts
+        if points.shape[1] == 2:
+            faces = np.hstack([np.full((m_verts.shape[0], 1), 3, dtype=np.int64), m_verts])
+            dom.mesh = pv.PolyData(m_nodes, faces)
+            dom.mesh = dom.mesh.compute_cell_sizes()
+            dom.mesh_tree = cKDTree(dom.mesh.cell_centers().points[:, :points.shape[1]], leafsize=4)
+            try:
+                from sklearn.neighbors import BallTree
+                dom.mesh_tree_2 = BallTree(dom.mesh.cell_centers().points[:, :points.shape[1]])
+            except Exception:  # pragma: no cover
+                dom.mesh_tree_2 = None
+            dom.all_mesh_cells = list(range(dom.mesh.n_cells))
+            dom.cumulative_probability = np.cumsum(dom.mesh.cell_data['Normalized_Area'])
+            dom.characteristic_length = dom.mesh.area ** (1 / points.shape[1])
+            dom.area = dom.mesh.area
+            dom.volume = 0.0
+        elif points.shape[1] == 3:
+            # Build tetra UnstructuredGrid
+            cells = np.hstack([np.full((m_verts.shape[0], 1), 4, dtype=np.int64), m_verts])
+            cell_types = [pv.CellType.TETRA for _ in range(m_verts.shape[0])]
+            dom.mesh = pv.UnstructuredGrid(cells, cell_types, m_nodes)
+            dom.mesh = dom.mesh.compute_cell_sizes()
+            dom.mesh_tree = cKDTree(dom.mesh.cell_centers().points[:, :points.shape[1]], leafsize=4)
+            try:
+                from sklearn.neighbors import BallTree
+                dom.mesh_tree_2 = BallTree(dom.mesh.cell_centers().points[:, :points.shape[1]])
+            except Exception:  # pragma: no cover
+                dom.mesh_tree_2 = None
+            dom.all_mesh_cells = list(range(dom.mesh.n_cells))
+            dom.cumulative_probability = np.cumsum(dom.mesh.cell_data['Normalized_Volume'])
+            dom.characteristic_length = dom.mesh.volume ** (1 / points.shape[1])
+            dom.area = dom.mesh.area
+            dom.volume = dom.mesh.volume
+
+    return dom

--- a/svv/utils/remeshing/remesh.py
+++ b/svv/utils/remeshing/remesh.py
@@ -8,8 +8,10 @@ import pyvista as pv
 import pymeshfix
 import meshio
 import numpy
+import numpy as np
 from copy import deepcopy
 import svv
+from typing import Sequence, Optional
 
 filepath = os.path.abspath(__file__)
 dirpath = os.path.dirname(filepath)
@@ -778,3 +780,257 @@ def clean_medit(filename):
                 new_lines.extend(lines[o:keywords_index[i+1]])
     new_file.writelines(new_lines)
     new_file.close()
+
+def write_medit_sol(mesh: pv.PolyData, path: str, array_name="MeshSizingFunction",
+                    scale=1, default_size=None):
+    npts = mesh.n_points
+    vals = None
+    if array_name in mesh.point_data:
+        vals = np.asarray(mesh.point_data[array_name], dtype=float).reshape(-1)
+        if vals.size != npts:
+            raise RuntimeError(f"Array '{array_name}' length ({vals.size}) "
+                               f"!= number of points ({npts})")
+          # Replace non-positive entries if default provided
+        if default_size is not None:
+            vals = np.where(vals > 0.0, vals, float(default_size))
+    else:
+        if default_size is None:
+            raise RuntimeError(f"Point-data array '{array_name}' not found and no default_size provided.")
+        vals = np.full(npts, float(default_size), dtype=float)
+
+    vals = scale * vals  # SV typically scales by ~0.8 before MMG
+
+    with open(path, "w") as f:
+        f.write("MeshVersionFormatted 2\n")
+        f.write("Dimension 3\n\n")
+        f.write("SolAtVertices\n")
+        f.write(f"{npts}\n")
+        f.write("1 1\n")  # one scalar per vertex
+        for v in vals:
+            f.write(f"{v:.15g}\n")
+        f.write("\nEnd\n")
+
+def sphere_refinement(
+      mesh: pv.PolyData,
+      radius: float,
+      center: Sequence[float],
+      local_edge_size: float,
+      global_edge_size: float,
+      array_name: str = "MeshSizingFunction",
+      refine_id_name: Optional[str] = None,
+      refine_id_value: int = 1,
+      inplace: bool = True,
+      ar=None,
+      hausd=None,
+      hgrad=None,
+      verbosity=1,
+      hmax=None,
+      hmin=None,
+      hsiz=None,
+      noinsert=None,
+      nomove=None,
+      nosurf=None,
+      noswap=None,
+      nr=None,
+      optim=False,
+      rn=None,
+      required_triangles=None
+  ) -> pv.PolyData:
+    """
+    Set local mesh edge size for points inside a sphere.
+
+    Args:
+
+    mesh: pyvista.PolyData surface mesh (triangulated or not).
+
+    radius: Sphere radius (> 0).
+
+    center: Sphere center [cx, cy, cz].
+
+    local_edge_size: Target edge size to assign inside the sphere (> 0).
+
+    array_name: Point-data array name to write (default: 'MeshSizingFunction').
+
+    global_edge_size: If provided and the array is missing, initialize all points
+          to this value. If not provided and the array is missing, initialize with zeros.
+          Points outside the sphere are left unchanged.
+
+    refine_id_name: Optional point-data int array to tag refined points
+          (e.g., 'RefineID'). If provided, sets tag = refine_id_value inside the sphere,
+          leaves others as-is (initializes to 0 if array missing).
+
+    refine_id_value: Tag value to set in refine_id_name for points in the sphere.
+
+    inplace: If False, process a deep copy and return it.
+
+    ar : float, optional
+        Anisotropy ratio. See MMG3D documentation for details.
+
+    hausd : float, optional
+        Control on Hausdorff distance. See MMG3D documentation.
+
+    hgrad : float, optional
+        Gradation parameter. See MMG3D documentation.
+
+    verbosity : int, optional
+        Verbosity level for MMG output. Default is 1.
+
+    hmax : float, optional
+        Maximum edge size. See MMG3D documentation.
+
+    hmin : float, optional
+        Minimum edge size. See MMG3D documentation.
+
+    hsiz : float, optional
+        Size parameter for remeshing. See MMG3D documentation.
+
+    noinsert : bool, optional
+        If True, prohibits node insertion. See MMG3D documentation.
+
+    nomove : bool, optional
+        If True, prohibits node movement. See MMG3D documentation.
+
+    nosurf : bool, optional
+        If True, prohibits surface modifications. See MMG3D documentation.
+
+    noswap : bool, optional
+        If True, prohibits edge swapping. See MMG3D documentation.
+
+    nr : bool, optional
+        Disables reorientation of the mesh. See MMG3D documentation.
+
+    optim : bool, optional
+        Optimization parameter. See MMG3D documentation.
+
+    rn : bool, optional
+        Removes nonmanifold elements. See MMG3D documentation.
+      Returns:
+        pv.PolyData: The updated mesh (same object if inplace=True).
+    """
+    if not isinstance(mesh, pv.PolyData):
+        raise TypeError("mesh must be a pyvista.PolyData")
+    if radius <= 0:
+        raise ValueError("radius must be > 0")
+    if local_edge_size <= 0:
+        raise ValueError("local_edge_size must be > 0")
+    if global_edge_size <= 0:
+        raise ValueError("global_edge_size must be > 0")
+
+    out = mesh if inplace else mesh.copy(deep=True)
+
+    pts = out.points.astype(float)
+    ctr = np.asarray(center, dtype=float).reshape(3)
+    if ctr.shape != (3,):
+        raise ValueError("center must be a sequence of three floats")
+
+    # Compute mask of points inside the sphere (vectorized).
+    d2 = np.einsum("ij,ij->i", pts - ctr, pts - ctr)  # squared distance
+    mask = d2 <= float(radius) ** 2
+
+    # Prepare or fetch the sizing array.
+    n = pts.shape[0]
+    if array_name in out.point_data:
+        sizes = np.asarray(out.point_data[array_name], dtype=float).copy()
+        if sizes.shape[0] != n:
+            raise RuntimeError(f"Existing array '{array_name}' length {sizes.shape[0]} != n_points {n}")
+    else:
+        if global_edge_size is None:
+            sizes = np.zeros(n, dtype=float)
+        else:
+            sizes = np.full(n, float(global_edge_size), dtype=float)
+
+    # Apply refinement.
+    sizes[mask] = float(local_edge_size)
+    out.point_data[array_name] = sizes
+
+    # Optional: tag refined points (like SimVascular's RefineID).
+    if refine_id_name:
+        if refine_id_name in out.point_data:
+            rid = np.asarray(out.point_data[refine_id_name], dtype=np.int32).copy()
+            if rid.shape[0] != n:
+                raise RuntimeError(f"Existing array '{refine_id_name}' length {rid.shape[0]} != n_points {n}")
+        else:
+            rid = np.zeros(n, dtype=np.int32)
+        rid[mask] = int(refine_id_value)
+        out.point_data[refine_id_name] = rid
+    write_medit_sol(out, "in.sol", array_name = "MeshSizingFunction",scale = 1, default_size = global_edge_size)
+    pv.save_meshio("tmp.mesh", out)
+    if not isinstance(required_triangles, type(None)):
+        add_required("tmp.mesh", required_triangles)
+    if platform.system() == 'Windows':
+        if os.path.exists(modulepath + os.sep + "mmgs_O3.exe"):
+            _EXE_ = modulepath + os.sep + "mmgs_O3.exe"
+        else:
+            _EXE_ = dirpath+os.sep+"Windows"+os.sep+"mmgs_O3.exe"
+    elif platform.system() == "Linux":
+        if os.path.exists(modulepath + os.sep + "mmgs_O3"):
+            _EXE_ = modulepath + os.sep + "mmgs_O3"
+        else:
+            _EXE_ = dirpath+os.sep+"Linux"+os.sep+"mmgs_O3"
+    elif platform.system() == "Darwin":
+        if os.path.exists(modulepath + os.sep + "mmgs_O3"):
+            _EXE_ = modulepath + os.sep + "mmgs_O3"
+        else:
+            _EXE_ = dirpath+os.sep+"Mac"+os.sep+"mmgs_O3"
+    else:
+        raise NotImplementedError("Operating system not supported.")
+    devnull = open(os.devnull, 'w')
+    executable_list = [_EXE_, "tmp.mesh", "-sol", "in.sol"]
+    if ar is not None:
+        executable_list.extend(["-ar", str(ar)])
+    if hausd is not None:
+        executable_list.extend(["-hausd", str(hausd)])
+    if hgrad is not None:
+        executable_list.extend(["-hgrad", str(hgrad)])
+    if verbosity is not None:
+        executable_list.extend(["-v", str(verbosity)])
+    if hmax is not None:
+        executable_list.extend(["-hmax", str(hmax)])
+    if hmin is not None:
+        executable_list.extend(["-hmin", str(hmin)])
+    if hsiz is not None:
+        executable_list.extend(["-hsiz", str(hsiz)])
+    if noinsert is not None:
+        executable_list.extend(["-noinsert"])
+    if nomove is not None:
+        executable_list.extend(["-nomove"])
+    if nosurf is not None:
+        executable_list.extend(["-nosurf"])
+    if noswap is not None:
+        executable_list.extend(["-noswap"])
+    if nr is not None:
+        executable_list.extend(["-nr"])
+    if optim:
+        executable_list.extend(["-optim"])
+    if rn is not None:
+        executable_list.extend(["-rn", str(rn)])
+    if verbosity == 0:
+        try:
+            subprocess.check_call(executable_list, stdout=devnull, stderr=devnull)
+        except:
+            os.chmod(_EXE_, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+            subprocess.check_call(executable_list, stdout=devnull, stderr=devnull)
+    else:
+        try:
+            subprocess.check_call(executable_list)
+        except:
+            os.chmod(_EXE_, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+            subprocess.check_call(executable_list)
+    clean_medit("tmp.o.mesh")
+    remesh_data = meshio.read("tmp.o.mesh")
+    vertices = remesh_data.points
+    has_triangles = False
+    for cell_block in remesh_data.cells:
+        if cell_block.type == "triangle":
+            faces = cell_block.data
+            has_triangles = True
+            break
+    if not has_triangles:
+        raise NotImplementedError("Only triangular surfaces are supported.")
+    faces = numpy.hstack([numpy.full((faces.shape[0], 1), 3), faces])
+    remeshed_surface = pv.PolyData(vertices, faces.flatten())
+    os.remove("tmp.mesh")
+    os.remove("tmp.o.sol")
+    os.remove("tmp.o.mesh")
+    os.remove("in.sol")
+    return remeshed_surface

--- a/svv/visualize/gui/README.md
+++ b/svv/visualize/gui/README.md
@@ -1,0 +1,249 @@
+# svVascularize GUI
+
+Interactive GUI for visualizing and manipulating Domain objects to configure Tree and Forest vascularization.
+
+## Features
+
+- **3D Domain Visualization**: View your domain mesh in an interactive 3D viewport
+- **Interactive Point Selection**: Click on the domain surface to select start points for trees
+- **Direction Control**: Optionally specify custom directions for tree growth
+- **Multi-Network Support**: Configure multiple networks with multiple trees per network
+- **Parameter Configuration**: Adjust tree/forest generation parameters
+- **Real-time Visualization**: See generated trees/forests in 3D
+- **Export Configuration**: Save your start points and parameters for later use
+
+## Installation
+
+The GUI requires PySide6 and PyVistaQt (with PyVista).
+
+Recommended (conda):
+```bash
+conda install -c conda-forge pyside6 pyvista pyvistaqt
+```
+
+Alternative (pip):
+```bash
+pip install PySide6 pyvista PyVistaQt
+```
+
+Notes:
+- On Linux, the GUI prefers software rendering (Mesa llvmpipe) to avoid GPU/driver issues. These settings are applied only on Linux and do not affect Windows or macOS. You can opt out with `SVV_GUI_GL_MODE=system`.
+- On Windows and macOS, no Mesa-specific setup is required.
+
+## Usage
+
+### Quick Launch
+
+Use the provided launcher script:
+
+```bash
+./launch_gui.sh
+```
+
+### Basic Usage (from Python)
+
+```python
+import os
+import sys
+
+from svv.visualize.gui import launch_gui
+
+# Launch and block until closed
+launch_gui()
+```
+
+### With Pre-loaded Domain
+
+```python
+from PySide6.QtWidgets import QApplication
+from svv.visualize.gui import VascularizeGUI
+from svv.domain.domain import Domain
+import pyvista as pv
+import sys
+
+# Create or load a domain
+sphere = pv.Sphere(radius=5.0)
+domain = Domain(sphere)
+domain.create()
+domain.solve()
+domain.build()
+
+# Launch GUI with domain (blocking)
+from svv.visualize.gui import launch_gui
+launch_gui(domain=domain)
+```
+
+### Example Script
+
+Run the included example:
+
+```bash
+python -m svv.visualize.gui.example_usage
+```
+
+### CLI Launch
+
+```bash
+python -m svv.visualize.gui
+python -m svv.visualize.gui --domain path/to/domain.dmn
+```
+
+## Linux Troubleshooting
+
+If you see libGL/Mesa warnings or a segmentation fault on launch, ensure your conda environment has Mesa userspace drivers and that the loader uses them instead of the system drivers.
+
+1. Use conda-forge packages and strict priority:
+   - `conda config --env --add channels conda-forge`
+   - `conda config --env --set channel_priority strict`
+2. Install GL stack (conda-forge):
+   - `conda install -y mesalib libglvnd libxcb xorg-libx11 xorg-libxt xorg-libxfixes`
+3. Point the driver loader to conda's DRI path and favor software GL:
+   - `export SVV_LIBGL_DRIVERS_PATH="$CONDA_PREFIX/lib/dri"`
+   - `export QT_OPENGL=software`
+   - `export MESA_LOADER_DRIVER_OVERRIDE=llvmpipe`
+   - If on Wayland: `export QT_QPA_PLATFORM=xcb`
+4. Launch again via Python or `python -m svv.visualize.gui`.
+
+Opt out and try system GL:
+- `export SVV_GUI_GL_MODE=system`  # disables Linux-specific software GL setup in the GUI
+
+These settings help avoid mixing system Mesa with conda libraries, which can cause crashes.
+
+## GUI Components
+
+### Main Window
+
+The main window is split into two panels:
+
+1. **Left Panel (70%)**: 3D visualization using PyVista
+2. **Right Panel (30%)**: Control widgets
+
+### Control Widgets
+
+#### Point Selector
+
+- **Networks**: Set the number of vascular networks
+- **Network/Tree Selection**: Choose which network and tree to add points to
+- **Pick Point**: Click on the domain surface to add start points
+- **Manual Input**: Enter point coordinates manually
+- **Direction Control**: Optionally specify custom growth directions
+- **Point List**: View and manage all added points
+
+#### Parameter Panel
+
+- **Generation Mode**: Choose between single tree or forest (multiple trees)
+- **Tree Parameters**:
+  - Number of vessels to generate
+  - Physical clearance between vessels
+  - Convexity tolerance
+- **Forest Parameters** (when in forest mode):
+  - Competition between trees
+  - Decay probability
+- **Advanced Parameters**:
+  - Random seed for reproducibility
+
+### Menu Bar
+
+- **File**:
+  - Load Domain: Load a .dmn domain file
+  - Save Configuration: Export start points and parameters to JSON
+  - Exit: Close the application
+- **View**:
+  - Reset Camera: Reset the 3D view
+  - Toggle Domain Visibility: Show/hide the domain mesh
+- **Help**:
+  - About: Show information about the application
+
+## Workflow
+
+1. **Load or Create a Domain**:
+   - Use `File -> Load Domain` to load a .dmn file, or
+   - Pass a domain object when creating the GUI
+
+2. **Configure Start Points**:
+   - Select the network and tree index
+   - Click "Pick Point" and click on the domain surface, or
+   - Use "Manual Input" to enter coordinates
+   - Optionally check "Use Custom Direction" and specify a direction vector
+
+3. **Set Parameters**:
+   - Choose generation mode (Tree or Forest)
+   - Set number of vessels
+   - Adjust physical clearance and other parameters
+
+4. **Generate**:
+   - Click "Generate Tree/Forest" to start generation
+   - View progress in the dialog
+   - See results in the 3D viewport
+
+5. **Export** (Optional):
+   - Use "File -> Save Configuration" to save your setup
+
+## API Reference
+
+### VascularizeGUI
+
+Main GUI window class.
+
+**Constructor:**
+```python
+VascularizeGUI(domain=None)
+```
+
+**Parameters:**
+- `domain` (svv.domain.Domain, optional): Initial domain to visualize
+
+**Methods:**
+- `load_domain(domain)`: Load a domain object
+- `update_status(message)`: Update the status bar
+
+### VTKWidget
+
+3D visualization widget.
+
+**Methods:**
+- `set_domain(domain)`: Set and visualize the domain
+- `add_start_point(point, index, color)`: Add a point marker
+- `add_direction(point, direction, length, color)`: Add a direction arrow
+- `add_tree(tree, color)`: Visualize a tree
+- `clear()`: Clear all visualizations except domain
+- `reset_camera()`: Reset camera view
+
+### PointSelectorWidget
+
+Widget for managing start points and directions.
+
+**Methods:**
+- `set_domain(domain)`: Set the domain
+- `get_configuration()`: Get current configuration as dictionary
+
+### ParameterPanel
+
+Widget for setting tree/forest parameters.
+
+**Methods:**
+- `get_parameters()`: Get current parameter values
+
+## Notes
+
+- The GUI uses PyVista's Qt integration for 3D rendering
+- Point picking is done by clicking directly on the domain surface
+- Directions are automatically normalized when using the "Normalize Direction" button
+- Generated trees/forests are stored in `gui.trees` or `gui.forest` for programmatic access
+
+## Troubleshooting
+
+### ImportError: No module named 'PySide6'
+
+Install the required dependencies:
+```bash
+pip install PySide6 pyvista PyVistaQt
+```
+
+### GUI not responding during generation
+
+Large tree/forest generation may take time. A progress dialog is shown during generation. For very large generations (>10000 vessels), consider using the non-GUI API.
+
+### Point picking not working
+
+Ensure the domain has a valid boundary mesh. The domain must be created, solved, and built before point picking will work properly.

--- a/svv/visualize/gui/__init__.py
+++ b/svv/visualize/gui/__init__.py
@@ -1,0 +1,88 @@
+import os
+import sys
+
+# CRITICAL: Set GL environment BEFORE any Qt/VTK imports
+# This must happen at module import time
+if sys.platform.startswith('linux'):
+    gl_mode = os.environ.get('SVV_GUI_GL_MODE', 'software')
+    if gl_mode != 'system':
+        os.environ.setdefault('LIBGL_ALWAYS_SOFTWARE', '1')
+        os.environ.setdefault('GALLIUM_DRIVER', 'llvmpipe')
+        os.environ.setdefault('MESA_GL_VERSION_OVERRIDE', '3.3')
+        os.environ.setdefault('MESA_LOADER_DRIVER_OVERRIDE', 'llvmpipe')
+        os.environ.setdefault('QT_OPENGL', 'software')
+
+        # Set DRI drivers path
+        override_dri = os.environ.get('SVV_LIBGL_DRIVERS_PATH')
+        if override_dri and os.path.isdir(override_dri):
+            os.environ.setdefault('LIBGL_DRIVERS_PATH', override_dri)
+        else:
+            conda_prefix = os.environ.get('CONDA_PREFIX', '')
+            if conda_prefix:
+                # Try environment-specific paths first
+                candidates = [
+                    os.path.join(conda_prefix, 'lib', 'dri'),
+                    os.path.join(conda_prefix, 'x86_64-conda-linux-gnu', 'sysroot', 'usr', 'lib64', 'dri'),
+                ]
+
+                # Also check base conda path (for cos7 packages installed at root)
+                # Extract base path from environment path
+                if '/envs/' in conda_prefix:
+                    base_prefix = conda_prefix.split('/envs/')[0]
+                    candidates.append(os.path.join(base_prefix, 'x86_64-conda-linux-gnu', 'sysroot', 'usr', 'lib64', 'dri'))
+
+                for dri_path in candidates:
+                    if os.path.isdir(dri_path):
+                        os.environ.setdefault('LIBGL_DRIVERS_PATH', dri_path)
+                        break
+
+        if 'WAYLAND_DISPLAY' in os.environ:
+            os.environ.setdefault('QT_QPA_PLATFORM', 'xcb')
+
+from svv.visualize.gui.main_window import VascularizeGUI
+
+
+def launch_gui(domain=None, block=True):
+    """
+    Launch the Vascularize GUI from a Python interpreter or script.
+
+    Parameters
+    ----------
+    domain : optional
+        Optional domain object to preload into the GUI.
+    block : bool
+        If True, start the Qt event loop and block until exit.
+        If False, return ``(app, gui)`` without starting the loop.
+
+    Returns
+    -------
+    tuple | None
+        ``(app, gui)`` when ``block=False``, otherwise ``None``.
+    """
+    import sys
+    from PySide6.QtWidgets import QApplication
+    from PySide6.QtCore import Qt
+
+    # On Linux, prefer Qt's software OpenGL to avoid GPU/driver issues
+    # unless explicitly opting into system GL.
+    if sys.platform.startswith('linux') and os.environ.get('SVV_GUI_GL_MODE', 'software') != 'system':
+        try:
+            QApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+        except Exception:
+            pass
+
+    app = QApplication.instance() or QApplication(sys.argv)
+    gui = VascularizeGUI(domain=domain)
+    gui.show()
+
+    if not block:
+        return app, gui
+
+    try:
+        app.exec()
+    except AttributeError:
+        app.exec_()
+    return None
+
+
+__all__ = ['VascularizeGUI', 'launch_gui']

--- a/svv/visualize/gui/__main__.py
+++ b/svv/visualize/gui/__main__.py
@@ -1,0 +1,103 @@
+"""
+Entry point for launching the svVascularize GUI as a module.
+
+Usage:
+    python -m svv.visualize.gui
+    python -m svv.visualize.gui --domain path/to/domain.dmn
+"""
+import sys
+import os
+import argparse
+
+# CRITICAL: Set GL environment BEFORE any imports
+if sys.platform.startswith('linux'):
+    gl_mode = os.environ.get('SVV_GUI_GL_MODE', 'software')
+    if gl_mode != 'system':
+        os.environ.setdefault('LIBGL_ALWAYS_SOFTWARE', '1')
+        os.environ.setdefault('GALLIUM_DRIVER', 'llvmpipe')
+        os.environ.setdefault('MESA_GL_VERSION_OVERRIDE', '3.3')
+        os.environ.setdefault('MESA_LOADER_DRIVER_OVERRIDE', 'llvmpipe')
+        os.environ.setdefault('QT_OPENGL', 'software')
+
+        # Set DRI drivers path
+        override_dri = os.environ.get('SVV_LIBGL_DRIVERS_PATH')
+        if override_dri and os.path.isdir(override_dri):
+            os.environ.setdefault('LIBGL_DRIVERS_PATH', override_dri)
+        else:
+            conda_prefix = os.environ.get('CONDA_PREFIX', '')
+            if conda_prefix:
+                # Try environment-specific paths first
+                candidates = [
+                    os.path.join(conda_prefix, 'lib', 'dri'),
+                    os.path.join(conda_prefix, 'x86_64-conda-linux-gnu', 'sysroot', 'usr', 'lib64', 'dri'),
+                ]
+
+                # Also check base conda path (for cos7 packages installed at root)
+                # Extract base path from environment path
+                if '/envs/' in conda_prefix:
+                    base_prefix = conda_prefix.split('/envs/')[0]
+                    candidates.append(os.path.join(base_prefix, 'x86_64-conda-linux-gnu', 'sysroot', 'usr', 'lib64', 'dri'))
+
+                for dri_path in candidates:
+                    if os.path.isdir(dri_path):
+                        os.environ.setdefault('LIBGL_DRIVERS_PATH', dri_path)
+                        break
+
+        if 'WAYLAND_DISPLAY' in os.environ:
+            os.environ.setdefault('QT_QPA_PLATFORM', 'xcb')
+
+from PySide6.QtWidgets import QApplication
+from PySide6.QtCore import Qt
+from svv.visualize.gui import VascularizeGUI
+
+
+def main():
+    """Main entry point for the GUI."""
+    parser = argparse.ArgumentParser(
+        description='svVascularize - Interactive Domain Visualization'
+    )
+    parser.add_argument(
+        '--domain',
+        type=str,
+        help='Path to a .dmn domain file to load on startup',
+        default=None
+    )
+
+    args = parser.parse_args()
+
+    # Configure Qt software OpenGL on Linux unless opting into system GL
+    if sys.platform.startswith('linux') and os.environ.get('SVV_GUI_GL_MODE', 'software') != 'system':
+        try:
+            QApplication.setAttribute(Qt.AA_UseSoftwareOpenGL)
+        except Exception:
+            pass
+
+    # Create Qt application
+    app = QApplication(sys.argv)
+
+    # Load domain if specified
+    domain = None
+    if args.domain:
+        try:
+            from svv.domain.domain import Domain
+            print(f"Loading domain from {args.domain}...")
+            domain = Domain.load(args.domain)
+            print("Domain loaded successfully.")
+        except Exception as e:
+            print(f"Error loading domain: {e}")
+            print("Starting with empty GUI...")
+
+    # Create and show GUI
+    gui = VascularizeGUI(domain=domain)
+    gui.show()
+
+    # Run application (Qt5/Qt6 compatible)
+    try:
+        exit_code = app.exec()
+    except AttributeError:
+        exit_code = app.exec_()
+    sys.exit(exit_code)
+
+
+if __name__ == '__main__':
+    main()

--- a/svv/visualize/gui/example_usage.py
+++ b/svv/visualize/gui/example_usage.py
@@ -1,0 +1,96 @@
+"""
+Example usage of the svVascularize GUI.
+
+This script demonstrates how to launch the GUI with and without a domain.
+"""
+import sys
+from PySide6.QtWidgets import QApplication
+from svv.visualize.gui import VascularizeGUI
+
+
+def example_empty():
+    """Launch GUI without a domain (domain can be loaded from menu)."""
+    app = QApplication(sys.argv)
+    gui = VascularizeGUI()
+    gui.show()
+    try:
+        sys.exit(app.exec())
+    except AttributeError:
+        sys.exit(app.exec_())
+
+
+def example_with_domain():
+    """Launch GUI with a pre-loaded domain."""
+    import pyvista as pv
+    from svv.domain.domain import Domain
+
+    # Create a simple cube domain
+    cube_mesh = pv.Cube()
+    domain = Domain(cube_mesh)
+    domain.create()
+    domain.solve()
+    domain.build()
+
+    # Launch GUI with domain
+    app = QApplication(sys.argv)
+    gui = VascularizeGUI(domain=domain)
+    gui.show()
+    try:
+        sys.exit(app.exec())
+    except AttributeError:
+        sys.exit(app.exec_())
+
+
+def example_with_sphere():
+    """Launch GUI with a sphere domain."""
+    import pyvista as pv
+    from svv.domain.domain import Domain
+
+    # Create a sphere domain
+    sphere = pv.Sphere(radius=5.0, theta_resolution=30, phi_resolution=30)
+    domain = Domain(sphere)
+    domain.create()
+    domain.solve()
+    domain.build()
+
+    # Launch GUI with domain
+    app = QApplication(sys.argv)
+    gui = VascularizeGUI(domain=domain)
+    gui.show()
+    try:
+        sys.exit(app.exec())
+    except AttributeError:
+        sys.exit(app.exec_())
+
+
+def example_load_from_file(dmn_file):
+    """Launch GUI with a domain loaded from a .dmn file."""
+    from svv.domain.domain import Domain
+
+    # Load domain from file
+    domain = Domain.load(dmn_file)
+
+    # Launch GUI with domain
+    app = QApplication(sys.argv)
+    gui = VascularizeGUI(domain=domain)
+    gui.show()
+    try:
+        sys.exit(app.exec())
+    except AttributeError:
+        sys.exit(app.exec_())
+
+
+if __name__ == "__main__":
+    # Choose which example to run:
+
+    # 1. Empty GUI (load domain from File menu)
+    # example_empty()
+
+    # 2. GUI with a cube domain
+    example_with_domain()
+
+    # 3. GUI with a sphere domain
+    # example_with_sphere()
+
+    # 4. GUI with domain loaded from file
+    # example_load_from_file("path/to/your/domain.dmn")

--- a/svv/visualize/gui/main_window.py
+++ b/svv/visualize/gui/main_window.py
@@ -1,0 +1,198 @@
+"""
+Main GUI window for svVascularize using PySide6.
+"""
+from PySide6.QtWidgets import (
+    QMainWindow, QWidget, QVBoxLayout, QHBoxLayout,
+    QSplitter, QMenuBar, QMenu, QStatusBar, QFileDialog,
+    QMessageBox
+)
+from PySide6.QtCore import Qt
+from svv.visualize.gui.vtk_widget import VTKWidget
+from svv.visualize.gui.point_selector import PointSelectorWidget
+from svv.visualize.gui.parameter_panel import ParameterPanel
+
+
+class VascularizeGUI(QMainWindow):
+    """
+    Main GUI window for visualizing and manipulating Domain objects
+    to configure Tree and Forest vascularization.
+    """
+
+    def __init__(self, domain=None):
+        """
+        Initialize the main GUI window.
+
+        Parameters
+        ----------
+        domain : svv.domain.Domain, optional
+            Initial domain object to visualize
+        """
+        super().__init__()
+        self.domain = domain
+        self.trees = []
+        self.forest = None
+
+        self.setWindowTitle("svVascularize - Domain Visualization")
+        self.setGeometry(100, 100, 1400, 900)
+
+        self._init_ui()
+        self._create_menu_bar()
+        self._create_status_bar()
+
+        # Load domain if provided
+        if domain is not None:
+            self.load_domain(domain)
+
+    def _init_ui(self):
+        """Initialize the user interface layout."""
+        # Create central widget
+        central_widget = QWidget()
+        self.setCentralWidget(central_widget)
+
+        # Main layout
+        main_layout = QHBoxLayout(central_widget)
+
+        # Create splitter for resizable panels
+        splitter = QSplitter(Qt.Horizontal)
+
+        # Left panel: 3D visualization
+        self.vtk_widget = VTKWidget(self)
+        splitter.addWidget(self.vtk_widget)
+
+        # Right panel: Controls
+        right_panel = QWidget()
+        right_layout = QVBoxLayout(right_panel)
+        right_layout.setContentsMargins(5, 5, 5, 5)
+
+        # Point selector widget
+        self.point_selector = PointSelectorWidget(self)
+        right_layout.addWidget(self.point_selector)
+
+        # Parameter panel
+        self.parameter_panel = ParameterPanel(self)
+        right_layout.addWidget(self.parameter_panel)
+
+        splitter.addWidget(right_panel)
+
+        # Set splitter proportions (70% visualization, 30% controls)
+        splitter.setSizes([1000, 400])
+
+        main_layout.addWidget(splitter)
+
+    def _create_menu_bar(self):
+        """Create the application menu bar."""
+        menubar = self.menuBar()
+
+        # File menu
+        file_menu = menubar.addMenu("&File")
+
+        load_domain_action = file_menu.addAction("Load Domain...")
+        load_domain_action.triggered.connect(self.load_domain_dialog)
+
+        save_config_action = file_menu.addAction("Save Configuration...")
+        save_config_action.triggered.connect(self.save_configuration)
+
+        file_menu.addSeparator()
+
+        exit_action = file_menu.addAction("E&xit")
+        exit_action.triggered.connect(self.close)
+
+        # View menu
+        view_menu = menubar.addMenu("&View")
+
+        reset_camera_action = view_menu.addAction("Reset Camera")
+        reset_camera_action.triggered.connect(self.vtk_widget.reset_camera)
+
+        toggle_domain_action = view_menu.addAction("Toggle Domain Visibility")
+        toggle_domain_action.triggered.connect(self.vtk_widget.toggle_domain_visibility)
+
+        # Help menu
+        help_menu = menubar.addMenu("&Help")
+
+        about_action = help_menu.addAction("About")
+        about_action.triggered.connect(self.show_about)
+
+    def _create_status_bar(self):
+        """Create the status bar."""
+        self.status_bar = QStatusBar()
+        self.setStatusBar(self.status_bar)
+        self.status_bar.showMessage("Ready")
+
+    def load_domain(self, domain):
+        """
+        Load a domain object into the visualization.
+
+        Parameters
+        ----------
+        domain : svv.domain.Domain
+            Domain object to visualize
+        """
+        self.domain = domain
+        self.vtk_widget.set_domain(domain)
+        self.point_selector.set_domain(domain)
+        self.status_bar.showMessage(f"Domain loaded successfully")
+
+    def load_domain_dialog(self):
+        """Open a file dialog to load a domain from a .dmn file."""
+        file_path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Load Domain",
+            "",
+            "Domain Files (*.dmn);;All Files (*)"
+        )
+
+        if file_path:
+            try:
+                from svv.domain.domain import Domain
+                domain = Domain.load(file_path)
+                self.load_domain(domain)
+            except Exception as e:
+                QMessageBox.critical(
+                    self,
+                    "Error Loading Domain",
+                    f"Failed to load domain:\n{str(e)}"
+                )
+
+    def save_configuration(self):
+        """Save the current start points and configuration."""
+        file_path, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save Configuration",
+            "",
+            "JSON Files (*.json);;All Files (*)"
+        )
+
+        if file_path:
+            try:
+                import json
+                config = self.point_selector.get_configuration()
+                with open(file_path, 'w') as f:
+                    json.dump(config, f, indent=2)
+                self.status_bar.showMessage(f"Configuration saved to {file_path}")
+            except Exception as e:
+                QMessageBox.critical(
+                    self,
+                    "Error Saving Configuration",
+                    f"Failed to save configuration:\n{str(e)}"
+                )
+
+    def show_about(self):
+        """Show the about dialog."""
+        QMessageBox.about(
+            self,
+            "About svVascularize",
+            "svVascularize Domain Visualization Tool\n\n"
+            "Interactive GUI for configuring vascular tree generation.\n\n"
+            "Built with PySide6 and PyVista"
+        )
+
+    def update_status(self, message):
+        """
+        Update the status bar message.
+
+        Parameters
+        ----------
+        message : str
+            Status message to display
+        """
+        self.status_bar.showMessage(message)

--- a/svv/visualize/gui/parameter_panel.py
+++ b/svv/visualize/gui/parameter_panel.py
@@ -1,0 +1,336 @@
+"""
+Parameter panel for configuring Tree and Forest generation.
+"""
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QGroupBox,
+    QPushButton, QLabel, QSpinBox, QDoubleSpinBox,
+    QComboBox, QCheckBox, QScrollArea, QFormLayout,
+    QMessageBox, QProgressDialog
+)
+from PySide6.QtCore import Signal, Qt
+
+
+class ParameterPanel(QWidget):
+    """
+    Widget for configuring Tree and Forest generation parameters.
+    """
+
+    # Signals
+    parameters_changed = Signal()
+
+    def __init__(self, parent=None):
+        """
+        Initialize the parameter panel.
+
+        Parameters
+        ----------
+        parent : QWidget, optional
+            Parent widget (should be VascularizeGUI)
+        """
+        super().__init__(parent)
+        self.parent_gui = parent
+
+        self._init_ui()
+
+    def _init_ui(self):
+        """Initialize the user interface."""
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        # Create scroll area for parameters
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll_content = QWidget()
+        scroll_layout = QVBoxLayout(scroll_content)
+
+        # Mode selection
+        mode_group = QGroupBox("Generation Mode")
+        mode_layout = QVBoxLayout()
+        mode_group.setLayout(mode_layout)
+
+        self.mode_combo = QComboBox()
+        self.mode_combo.addItem("Single Tree")
+        self.mode_combo.addItem("Forest (Multiple Trees)")
+        self.mode_combo.currentIndexChanged.connect(self._on_mode_changed)
+        mode_layout.addWidget(self.mode_combo)
+
+        scroll_layout.addWidget(mode_group)
+
+        # Tree parameters
+        tree_params_group = QGroupBox("Tree Parameters")
+        tree_form = QFormLayout()
+        tree_params_group.setLayout(tree_form)
+
+        self.n_vessels_spin = QSpinBox()
+        self.n_vessels_spin.setRange(1, 100000)
+        self.n_vessels_spin.setValue(100)
+        tree_form.addRow("Number of Vessels:", self.n_vessels_spin)
+
+        self.physical_clearance_spin = QDoubleSpinBox()
+        self.physical_clearance_spin.setRange(0.0, 10.0)
+        self.physical_clearance_spin.setSingleStep(0.01)
+        self.physical_clearance_spin.setDecimals(4)
+        self.physical_clearance_spin.setValue(0.0)
+        tree_form.addRow("Physical Clearance:", self.physical_clearance_spin)
+
+        self.convexity_tolerance_spin = QDoubleSpinBox()
+        self.convexity_tolerance_spin.setRange(0.0, 1.0)
+        self.convexity_tolerance_spin.setSingleStep(0.01)
+        self.convexity_tolerance_spin.setDecimals(3)
+        self.convexity_tolerance_spin.setValue(0.01)
+        tree_form.addRow("Convexity Tolerance:", self.convexity_tolerance_spin)
+
+        scroll_layout.addWidget(tree_params_group)
+
+        # Forest parameters (initially hidden)
+        self.forest_params_group = QGroupBox("Forest Parameters")
+        forest_form = QFormLayout()
+        self.forest_params_group.setLayout(forest_form)
+
+        self.compete_cb = QCheckBox("Enable Competition")
+        forest_form.addRow("Competition:", self.compete_cb)
+
+        self.decay_probability_spin = QDoubleSpinBox()
+        self.decay_probability_spin.setRange(0.0, 1.0)
+        self.decay_probability_spin.setSingleStep(0.05)
+        self.decay_probability_spin.setDecimals(2)
+        self.decay_probability_spin.setValue(0.9)
+        forest_form.addRow("Decay Probability:", self.decay_probability_spin)
+
+        scroll_layout.addWidget(self.forest_params_group)
+        self.forest_params_group.hide()
+
+        # Advanced parameters
+        advanced_group = QGroupBox("Advanced Parameters")
+        advanced_form = QFormLayout()
+        advanced_group.setLayout(advanced_form)
+
+        self.random_seed_spin = QSpinBox()
+        self.random_seed_spin.setRange(-1, 999999)
+        self.random_seed_spin.setValue(-1)
+        self.random_seed_spin.setSpecialValueText("Random")
+        advanced_form.addRow("Random Seed:", self.random_seed_spin)
+
+        scroll_layout.addWidget(advanced_group)
+
+        # Add stretch to push everything to top
+        scroll_layout.addStretch()
+
+        scroll.setWidget(scroll_content)
+        layout.addWidget(scroll)
+
+        # Action buttons
+        button_layout = QVBoxLayout()
+
+        self.generate_btn = QPushButton("Generate Tree/Forest")
+        self.generate_btn.clicked.connect(self._generate)
+        self.generate_btn.setStyleSheet("font-weight: bold; padding: 10px;")
+        button_layout.addWidget(self.generate_btn)
+
+        self.export_btn = QPushButton("Export Configuration")
+        self.export_btn.clicked.connect(self._export_config)
+        button_layout.addWidget(self.export_btn)
+
+        layout.addLayout(button_layout)
+
+    def _on_mode_changed(self, index):
+        """Handle mode selection change."""
+        if index == 0:  # Single Tree
+            self.forest_params_group.hide()
+        else:  # Forest
+            self.forest_params_group.show()
+
+    def _generate(self):
+        """Generate Tree or Forest based on current configuration."""
+        if not self.parent_gui or not self.parent_gui.domain:
+            QMessageBox.warning(
+                self,
+                "No Domain",
+                "Please load a domain before generating trees."
+            )
+            return
+
+        # Get configuration
+        mode = self.mode_combo.currentIndex()
+        n_vessels = self.n_vessels_spin.value()
+        physical_clearance = self.physical_clearance_spin.value()
+        convexity_tolerance = self.convexity_tolerance_spin.value()
+        random_seed = self.random_seed_spin.value() if self.random_seed_spin.value() >= 0 else None
+
+        # Get start points configuration
+        point_config = self.parent_gui.point_selector.get_configuration()
+
+        try:
+            if mode == 0:  # Single Tree
+                self._generate_tree(
+                    n_vessels,
+                    physical_clearance,
+                    convexity_tolerance,
+                    random_seed,
+                    point_config
+                )
+            else:  # Forest
+                compete = self.compete_cb.isChecked()
+                decay_prob = self.decay_probability_spin.value()
+                self._generate_forest(
+                    n_vessels,
+                    physical_clearance,
+                    convexity_tolerance,
+                    random_seed,
+                    compete,
+                    decay_prob,
+                    point_config
+                )
+
+        except Exception as e:
+            QMessageBox.critical(
+                self,
+                "Generation Error",
+                f"Failed to generate tree/forest:\n{str(e)}"
+            )
+
+    def _generate_tree(self, n_vessels, physical_clearance, convexity_tolerance, random_seed, config):
+        """Generate a single tree."""
+        from svv.tree.tree import Tree
+
+        # Create progress dialog
+        progress = QProgressDialog("Generating tree...", "Cancel", 0, n_vessels, self)
+        progress.setWindowModality(Qt.WindowModal)
+        progress.setMinimumDuration(0)
+
+        # Create tree
+        tree = Tree()
+        tree.physical_clearance = physical_clearance
+        if random_seed is not None:
+            tree.random_seed = random_seed
+
+        # Set domain
+        tree.set_domain(self.parent_gui.domain, convexity_tolerance)
+
+        # Get start point and direction
+        start_point = None
+        direction = None
+
+        if config['start_points'][0][0] is not None:
+            start_point = config['start_points'][0][0]
+            if config['directions'][0][0] is not None:
+                direction = config['directions'][0][0]
+
+        # Set root
+        if start_point is not None:
+            if direction is not None:
+                tree.set_root(start_point, direction)
+            else:
+                tree.set_root(start_point)
+        else:
+            tree.set_root()
+
+        # Generate vessels
+        for i in range(n_vessels):
+            if progress.wasCanceled():
+                break
+
+            tree.add()
+            progress.setValue(i + 1)
+
+        progress.close()
+
+        # Visualize
+        self.parent_gui.vtk_widget.clear_trees()
+        self.parent_gui.vtk_widget.add_tree(tree)
+
+        # Store tree
+        self.parent_gui.trees = [tree]
+
+        QMessageBox.information(
+            self,
+            "Success",
+            f"Tree generated with {tree.n_terminals} vessels."
+        )
+
+    def _generate_forest(self, n_vessels, physical_clearance, convexity_tolerance,
+                        random_seed, compete, decay_prob, config):
+        """Generate a forest."""
+        from svv.forest.forest import Forest
+
+        # Create progress dialog
+        progress = QProgressDialog("Generating forest...", "Cancel", 0, n_vessels, self)
+        progress.setWindowModality(Qt.WindowModal)
+        progress.setMinimumDuration(0)
+
+        # Extract forest configuration
+        n_networks = config['n_networks']
+        n_trees_per_network = config['n_trees_per_network']
+        start_points = config['start_points']
+        directions = config['directions']
+
+        # Create forest
+        forest = Forest(
+            domain=self.parent_gui.domain,
+            n_networks=n_networks,
+            n_trees_per_network=n_trees_per_network,
+            start_points=start_points,
+            directions=directions,
+            physical_clearance=physical_clearance,
+            compete=compete
+        )
+
+        # Set domain
+        forest.set_domain(self.parent_gui.domain, convexity_tolerance)
+
+        # Set roots
+        forest.set_roots(start_points, directions)
+
+        # Generate vessels
+        for i in range(n_vessels):
+            if progress.wasCanceled():
+                break
+
+            forest.add(1, decay_probability=decay_prob)
+            progress.setValue(i + 1)
+
+        progress.close()
+
+        # Visualize
+        self.parent_gui.vtk_widget.clear_trees()
+        colors = ['red', 'blue', 'green', 'yellow', 'purple', 'orange']
+        color_idx = 0
+
+        for network in forest.networks:
+            for tree in network:
+                self.parent_gui.vtk_widget.add_tree(tree, color=colors[color_idx % len(colors)])
+                color_idx += 1
+
+        # Store forest
+        self.parent_gui.forest = forest
+
+        total_vessels = sum(tree.n_terminals for network in forest.networks for tree in network)
+        QMessageBox.information(
+            self,
+            "Success",
+            f"Forest generated with {total_vessels} total vessels across {n_networks} networks."
+        )
+
+    def _export_config(self):
+        """Export the current configuration."""
+        if self.parent_gui:
+            self.parent_gui.save_configuration()
+
+    def get_parameters(self):
+        """
+        Get the current parameter configuration.
+
+        Returns
+        -------
+        dict
+            Dictionary of parameters
+        """
+        return {
+            'mode': 'tree' if self.mode_combo.currentIndex() == 0 else 'forest',
+            'n_vessels': self.n_vessels_spin.value(),
+            'physical_clearance': self.physical_clearance_spin.value(),
+            'convexity_tolerance': self.convexity_tolerance_spin.value(),
+            'random_seed': self.random_seed_spin.value() if self.random_seed_spin.value() >= 0 else None,
+            'compete': self.compete_cb.isChecked(),
+            'decay_probability': self.decay_probability_spin.value()
+        }

--- a/svv/visualize/gui/point_selector.py
+++ b/svv/visualize/gui/point_selector.py
@@ -1,0 +1,436 @@
+"""
+Widget for selecting and managing start points and directions.
+"""
+import numpy as np
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QHBoxLayout, QGroupBox,
+    QPushButton, QListWidget, QListWidgetItem,
+    QLabel, QLineEdit, QCheckBox, QSpinBox,
+    QDoubleSpinBox, QComboBox
+)
+from PySide6.QtCore import Signal
+
+
+class PointSelectorWidget(QWidget):
+    """
+    Widget for managing start points and directions for Tree/Forest generation.
+    """
+
+    # Signals
+    points_changed = Signal()
+
+    def __init__(self, parent=None):
+        """
+        Initialize the point selector widget.
+
+        Parameters
+        ----------
+        parent : QWidget, optional
+            Parent widget (should be VascularizeGUI)
+        """
+        super().__init__(parent)
+        self.parent_gui = parent
+        self.domain = None
+        self.points = []  # List of dicts with 'point', 'direction', 'network', 'tree_index'
+
+        self._init_ui()
+
+    def _init_ui(self):
+        """Initialize the user interface."""
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        # Group box for point management
+        group_box = QGroupBox("Start Points & Directions")
+        group_layout = QVBoxLayout()
+        group_box.setLayout(group_layout)
+
+        # Network configuration
+        network_layout = QHBoxLayout()
+        network_layout.addWidget(QLabel("Networks:"))
+        self.network_spin = QSpinBox()
+        self.network_spin.setMinimum(1)
+        self.network_spin.setMaximum(10)
+        self.network_spin.setValue(1)
+        self.network_spin.valueChanged.connect(self._on_network_changed)
+        network_layout.addWidget(self.network_spin)
+        network_layout.addStretch()
+        group_layout.addLayout(network_layout)
+
+        # Current network/tree selection
+        selection_layout = QHBoxLayout()
+        selection_layout.addWidget(QLabel("Network:"))
+        self.network_combo = QComboBox()
+        self.network_combo.addItem("Network 0")
+        selection_layout.addWidget(self.network_combo)
+
+        selection_layout.addWidget(QLabel("Tree:"))
+        self.tree_combo = QComboBox()
+        self.tree_combo.addItem("Tree 0")
+        self.tree_combo.addItem("Tree 1")
+        selection_layout.addWidget(self.tree_combo)
+        group_layout.addLayout(selection_layout)
+
+        # Point list
+        self.point_list = QListWidget()
+        self.point_list.itemClicked.connect(self._on_point_selected)
+        group_layout.addWidget(QLabel("Points:"))
+        group_layout.addWidget(self.point_list)
+
+        # Add point buttons
+        button_layout = QHBoxLayout()
+
+        self.pick_mode_btn = QPushButton("Pick Point (Click on Domain)")
+        self.pick_mode_btn.setCheckable(True)
+        self.pick_mode_btn.clicked.connect(self._toggle_pick_mode)
+        button_layout.addWidget(self.pick_mode_btn)
+
+        self.manual_btn = QPushButton("Manual Input...")
+        self.manual_btn.clicked.connect(self._manual_input)
+        button_layout.addWidget(self.manual_btn)
+
+        group_layout.addLayout(button_layout)
+
+        # Point details
+        details_group = QGroupBox("Point Details")
+        details_layout = QVBoxLayout()
+        details_group.setLayout(details_layout)
+
+        # Coordinates
+        coord_layout = QHBoxLayout()
+        coord_layout.addWidget(QLabel("Position:"))
+        self.coord_label = QLabel("(0.0, 0.0, 0.0)")
+        coord_layout.addWidget(self.coord_label)
+        coord_layout.addStretch()
+        details_layout.addLayout(coord_layout)
+
+        # Direction checkbox
+        self.use_direction_cb = QCheckBox("Use Custom Direction")
+        self.use_direction_cb.stateChanged.connect(self._on_direction_toggled)
+        details_layout.addWidget(self.use_direction_cb)
+
+        # Direction inputs
+        direction_layout = QHBoxLayout()
+        direction_layout.addWidget(QLabel("Direction:"))
+        self.dir_x = QDoubleSpinBox()
+        self.dir_x.setRange(-1.0, 1.0)
+        self.dir_x.setSingleStep(0.1)
+        self.dir_x.setDecimals(3)
+        self.dir_x.valueChanged.connect(self._on_direction_changed)
+        direction_layout.addWidget(QLabel("X:"))
+        direction_layout.addWidget(self.dir_x)
+
+        self.dir_y = QDoubleSpinBox()
+        self.dir_y.setRange(-1.0, 1.0)
+        self.dir_y.setSingleStep(0.1)
+        self.dir_y.setDecimals(3)
+        self.dir_y.valueChanged.connect(self._on_direction_changed)
+        direction_layout.addWidget(QLabel("Y:"))
+        direction_layout.addWidget(self.dir_y)
+
+        self.dir_z = QDoubleSpinBox()
+        self.dir_z.setRange(-1.0, 1.0)
+        self.dir_z.setSingleStep(0.1)
+        self.dir_z.setDecimals(3)
+        self.dir_z.valueChanged.connect(self._on_direction_changed)
+        direction_layout.addWidget(QLabel("Z:"))
+        direction_layout.addWidget(self.dir_z)
+
+        details_layout.addLayout(direction_layout)
+
+        # Normalize button
+        self.normalize_btn = QPushButton("Normalize Direction")
+        self.normalize_btn.clicked.connect(self._normalize_direction)
+        details_layout.addWidget(self.normalize_btn)
+
+        # Initially disable direction inputs
+        self._enable_direction_inputs(False)
+
+        group_layout.addWidget(details_group)
+
+        # Delete and Clear buttons
+        action_layout = QHBoxLayout()
+        self.delete_btn = QPushButton("Delete Selected")
+        self.delete_btn.clicked.connect(self._delete_selected)
+        action_layout.addWidget(self.delete_btn)
+
+        self.clear_btn = QPushButton("Clear All")
+        self.clear_btn.clicked.connect(self._clear_all)
+        action_layout.addWidget(self.clear_btn)
+
+        group_layout.addLayout(action_layout)
+
+        layout.addWidget(group_box)
+
+    def set_domain(self, domain):
+        """
+        Set the domain for point selection.
+
+        Parameters
+        ----------
+        domain : svv.domain.Domain
+            Domain object
+        """
+        self.domain = domain
+
+    def _toggle_pick_mode(self, checked):
+        """Toggle point picking mode."""
+        if checked and self.parent_gui:
+            self.pick_mode_btn.setText("Picking... (Click Domain)")
+            # Connect to VTK widget's point picking signal
+            self.parent_gui.vtk_widget.point_picked.connect(self._on_point_picked)
+        else:
+            self.pick_mode_btn.setText("Pick Point (Click on Domain)")
+            if self.parent_gui:
+                try:
+                    self.parent_gui.vtk_widget.point_picked.disconnect(self._on_point_picked)
+                except:
+                    pass
+
+    def _on_point_picked(self, point):
+        """
+        Handle picked point from VTK widget.
+
+        Parameters
+        ----------
+        point : np.ndarray
+            Picked point coordinates
+        """
+        network = self.network_combo.currentIndex()
+        tree_idx = self.tree_combo.currentIndex()
+
+        point_data = {
+            'point': point,
+            'direction': None,
+            'network': network,
+            'tree_index': tree_idx
+        }
+
+        self.points.append(point_data)
+        self._update_point_list()
+        self._visualize_point(point_data, len(self.points) - 1)
+
+        # Update status
+        if self.parent_gui:
+            self.parent_gui.update_status(
+                f"Added point at ({point[0]:.3f}, {point[1]:.3f}, {point[2]:.3f})"
+            )
+
+        # Disable pick mode after picking
+        self.pick_mode_btn.setChecked(False)
+        self._toggle_pick_mode(False)
+
+        self.points_changed.emit()
+
+    def _manual_input(self):
+        """Open dialog for manual point input."""
+        from PySide6.QtWidgets import QDialog, QFormLayout, QDialogButtonBox
+
+        dialog = QDialog(self)
+        dialog.setWindowTitle("Manual Point Input")
+        layout = QFormLayout()
+
+        x_input = QDoubleSpinBox()
+        x_input.setRange(-1000, 1000)
+        x_input.setDecimals(3)
+        layout.addRow("X:", x_input)
+
+        y_input = QDoubleSpinBox()
+        y_input.setRange(-1000, 1000)
+        y_input.setDecimals(3)
+        layout.addRow("Y:", y_input)
+
+        z_input = QDoubleSpinBox()
+        z_input.setRange(-1000, 1000)
+        z_input.setDecimals(3)
+        layout.addRow("Z:", z_input)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        )
+        buttons.accepted.connect(dialog.accept)
+        buttons.rejected.connect(dialog.reject)
+        layout.addRow(buttons)
+
+        dialog.setLayout(layout)
+
+        if dialog.exec_():
+            point = np.array([x_input.value(), y_input.value(), z_input.value()])
+            self._on_point_picked(point)
+
+    def _on_point_selected(self, item):
+        """Handle point selection from list."""
+        idx = self.point_list.row(item)
+        if idx < len(self.points):
+            point_data = self.points[idx]
+            point = point_data['point']
+            direction = point_data['direction']
+
+            self.coord_label.setText(f"({point[0]:.3f}, {point[1]:.3f}, {point[2]:.3f})")
+
+            if direction is not None:
+                self.use_direction_cb.setChecked(True)
+                self.dir_x.setValue(direction[0])
+                self.dir_y.setValue(direction[1])
+                self.dir_z.setValue(direction[2])
+            else:
+                self.use_direction_cb.setChecked(False)
+
+    def _on_direction_toggled(self, state):
+        """Handle direction checkbox toggle."""
+        enabled = state == 2  # Qt.Checked
+        self._enable_direction_inputs(enabled)
+
+        if enabled:
+            # Set default direction if needed
+            if self.dir_x.value() == 0 and self.dir_y.value() == 0 and self.dir_z.value() == 0:
+                self.dir_z.setValue(1.0)
+
+        self._update_selected_point_direction()
+
+    def _on_direction_changed(self):
+        """Handle direction value changes."""
+        self._update_selected_point_direction()
+
+    def _normalize_direction(self):
+        """Normalize the current direction vector."""
+        direction = np.array([self.dir_x.value(), self.dir_y.value(), self.dir_z.value()])
+        norm = np.linalg.norm(direction)
+        if norm > 0:
+            direction = direction / norm
+            self.dir_x.setValue(direction[0])
+            self.dir_y.setValue(direction[1])
+            self.dir_z.setValue(direction[2])
+
+    def _update_selected_point_direction(self):
+        """Update the direction of the currently selected point."""
+        current_item = self.point_list.currentItem()
+        if current_item is not None:
+            idx = self.point_list.row(current_item)
+            if idx < len(self.points):
+                if self.use_direction_cb.isChecked():
+                    direction = np.array([
+                        self.dir_x.value(),
+                        self.dir_y.value(),
+                        self.dir_z.value()
+                    ])
+                    self.points[idx]['direction'] = direction
+                    self._update_direction_visualization(idx)
+                else:
+                    self.points[idx]['direction'] = None
+                    self._clear_direction_visualization(idx)
+
+                self.points_changed.emit()
+
+    def _enable_direction_inputs(self, enabled):
+        """Enable or disable direction input fields."""
+        self.dir_x.setEnabled(enabled)
+        self.dir_y.setEnabled(enabled)
+        self.dir_z.setEnabled(enabled)
+        self.normalize_btn.setEnabled(enabled)
+
+    def _delete_selected(self):
+        """Delete the selected point."""
+        current_item = self.point_list.currentItem()
+        if current_item is not None:
+            idx = self.point_list.row(current_item)
+            if idx < len(self.points):
+                self.points.pop(idx)
+                self._update_point_list()
+                self._refresh_visualization()
+                self.points_changed.emit()
+
+    def _clear_all(self):
+        """Clear all points."""
+        self.points.clear()
+        self._update_point_list()
+        if self.parent_gui:
+            self.parent_gui.vtk_widget.clear()
+        self.points_changed.emit()
+
+    def _on_network_changed(self, value):
+        """Handle network count change."""
+        # Update network combo box
+        self.network_combo.clear()
+        for i in range(value):
+            self.network_combo.addItem(f"Network {i}")
+
+    def _update_point_list(self):
+        """Update the point list widget."""
+        self.point_list.clear()
+        for i, point_data in enumerate(self.points):
+            point = point_data['point']
+            network = point_data['network']
+            tree_idx = point_data['tree_index']
+            has_dir = point_data['direction'] is not None
+
+            label = f"P{i}: N{network}T{tree_idx} ({point[0]:.2f}, {point[1]:.2f}, {point[2]:.2f})"
+            if has_dir:
+                label += " [Dir]"
+
+            self.point_list.addItem(label)
+
+    def _visualize_point(self, point_data, index):
+        """Visualize a single point."""
+        if self.parent_gui:
+            vtk_widget = self.parent_gui.vtk_widget
+            point = point_data['point']
+            direction = point_data['direction']
+
+            vtk_widget.add_start_point(point, index=index)
+
+            if direction is not None:
+                vtk_widget.add_direction(point, direction)
+
+    def _update_direction_visualization(self, index):
+        """Update direction visualization for a point."""
+        if self.parent_gui and index < len(self.points):
+            # For simplicity, refresh all visualizations
+            self._refresh_visualization()
+
+    def _clear_direction_visualization(self, index):
+        """Clear direction visualization for a point."""
+        if self.parent_gui:
+            # For simplicity, refresh all visualizations
+            self._refresh_visualization()
+
+    def _refresh_visualization(self):
+        """Refresh all point and direction visualizations."""
+        if self.parent_gui:
+            vtk_widget = self.parent_gui.vtk_widget
+            vtk_widget.clear()
+
+            for i, point_data in enumerate(self.points):
+                self._visualize_point(point_data, i)
+
+    def get_configuration(self):
+        """
+        Get the current configuration as a dictionary.
+
+        Returns
+        -------
+        dict
+            Configuration with start_points and directions for Forest
+        """
+        n_networks = self.network_spin.value()
+
+        # Organize points by network and tree
+        config = {
+            'n_networks': n_networks,
+            'n_trees_per_network': [2] * n_networks,  # Default to 2 trees per network
+            'start_points': [[None, None] for _ in range(n_networks)],
+            'directions': [[None, None] for _ in range(n_networks)]
+        }
+
+        for point_data in self.points:
+            network = point_data['network']
+            tree_idx = point_data['tree_index']
+            point = point_data['point']
+            direction = point_data['direction']
+
+            if network < n_networks and tree_idx < 2:
+                config['start_points'][network][tree_idx] = point.tolist()
+                if direction is not None:
+                    config['directions'][network][tree_idx] = direction.tolist()
+
+        return config

--- a/svv/visualize/gui/requirements-gui.txt
+++ b/svv/visualize/gui/requirements-gui.txt
@@ -1,0 +1,9 @@
+# GUI-specific requirements for svVascularize
+# Install with: pip install -r requirements-gui.txt
+
+# Qt bindings (PySide6 only)
+PySide6>=6.4.0
+
+# PyVista and Qt integration
+pyvista>=0.41
+pyvistaqt>=0.11.0

--- a/svv/visualize/gui/vtk_widget.py
+++ b/svv/visualize/gui/vtk_widget.py
@@ -1,0 +1,365 @@
+"""
+VTK/PyVista widget for 3D domain visualization.
+"""
+import os
+import sys
+
+# Configure software rendering only on Linux to ensure in-window rendering
+# without imposing Mesa settings on Windows/macOS.
+if sys.platform.startswith('linux'):
+    # Allow users to opt out of software GL and use system drivers
+    gl_mode = os.environ.get('SVV_GUI_GL_MODE', 'software')  # 'software' or 'system'
+    if gl_mode != 'system':
+        # Prefer software rendering to avoid GPU/driver issues on varied Linux setups
+        os.environ.setdefault('LIBGL_ALWAYS_SOFTWARE', '1')
+        os.environ.setdefault('GALLIUM_DRIVER', 'llvmpipe')
+        os.environ.setdefault('MESA_GL_VERSION_OVERRIDE', '3.3')
+        # Allow overriding the Mesa software driver
+        sw_driver = os.environ.get('SVV_GUI_SOFTWARE_DRIVER', 'llvmpipe')
+        os.environ.setdefault('MESA_LOADER_DRIVER_OVERRIDE', sw_driver)
+
+        # Qt side: force software OpenGL and use XCB when on Wayland
+        os.environ.setdefault('QT_OPENGL', 'software')
+        if 'WAYLAND_DISPLAY' in os.environ:
+            os.environ.setdefault('QT_QPA_PLATFORM', 'xcb')
+
+        # Allow explicit override of the DRI drivers path
+        override_dri = os.environ.get('SVV_LIBGL_DRIVERS_PATH')
+        if override_dri and os.path.isdir(override_dri):
+            os.environ.setdefault('LIBGL_DRIVERS_PATH', override_dri)
+        else:
+            # Common conda‑forge location
+            conda_prefix = os.environ.get('CONDA_PREFIX', '')
+            candidates = []
+            if conda_prefix:
+                candidates.extend([
+                    os.path.join(conda_prefix, 'lib', 'dri'),
+                    os.path.join(conda_prefix, 'x86_64-conda-linux-gnu', 'sysroot', 'usr', 'lib64', 'dri'),
+                ])
+            for dri_path in candidates:
+                if os.path.isdir(dri_path):
+                    os.environ.setdefault('LIBGL_DRIVERS_PATH', dri_path)
+                    break
+
+    # Optional debug output for GL setup
+    if os.environ.get('SVV_GUI_DEBUG_GL') == '1':
+        debug_state = {
+            'gl_mode': gl_mode,
+            'SVV_GUI_SOFTWARE_DRIVER': os.environ.get('SVV_GUI_SOFTWARE_DRIVER'),
+            'MESA_LOADER_DRIVER_OVERRIDE': os.environ.get('MESA_LOADER_DRIVER_OVERRIDE'),
+            'LIBGL_DRIVERS_PATH': os.environ.get('LIBGL_DRIVERS_PATH'),
+            'QT_QPA_PLATFORM': os.environ.get('QT_QPA_PLATFORM'),
+            'QT_OPENGL': os.environ.get('QT_OPENGL'),
+            'WAYLAND_DISPLAY': os.environ.get('WAYLAND_DISPLAY'),
+        }
+        print('[svv.gui] GL debug config:', debug_state)
+
+import numpy as np
+from PySide6.QtWidgets import QVBoxLayout, QWidget
+from PySide6.QtCore import Signal
+
+
+class VTKWidget(QWidget):
+    """
+    Widget for 3D visualization of Domain objects using PyVista.
+    """
+
+    # Signals
+    point_picked = Signal(object)  # Emitted when a point is picked (numpy array)
+
+    def __init__(self, parent=None):
+        """
+        Initialize the VTK widget.
+
+        Parameters
+        ----------
+        parent : QWidget, optional
+            Parent widget
+        """
+        super().__init__(parent)
+        self.domain = None
+        self.domain_actor = None
+        self.points_actors = []
+        self.direction_actors = []
+        self.tree_actors = []
+
+        # Attempt to import PyVista and PyVistaQt lazily with helpful errors
+        try:
+            from pyvistaqt import QtInteractor as _QtInteractor
+            import pyvista as _pv
+        except Exception as e:
+            # Provide a clearer error, especially for missing libffi on Linux
+            msg = (
+                "Failed to import PyVista/PyVistaQt. On Linux, ensure libffi is installed "
+                "(conda: `conda install -c conda-forge libffi>=3.4,<3.5`; system: `sudo apt install libffi8` on Ubuntu 22.04 "
+                "or `libffi7` on Ubuntu 20.04). Also install dependencies: PySide6, pyvista, pyvistaqt."
+            )
+            raise RuntimeError(msg) from e
+
+        self._pv = _pv
+        self._QtInteractor = _QtInteractor
+
+        # Create layout
+        layout = QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.setLayout(layout)
+
+        # Create PyVista plotter
+        self.plotter = self._QtInteractor(self)
+        layout.addWidget(self.plotter.interactor)
+
+        # Enable point picking
+        self.plotter.enable_point_picking(
+            callback=self._on_point_picked,
+            show_message=True,
+            color='red',
+            point_size=10
+        )
+
+        # Set background
+        self.plotter.set_background('white')
+
+        # Initial camera setup
+        self.plotter.camera_position = 'iso'
+
+    def set_domain(self, domain):
+        """
+        Set and visualize the domain.
+
+        Parameters
+        ----------
+        domain : svv.domain.Domain
+            Domain object to visualize
+        """
+        self.domain = domain
+        self.clear()
+
+        # Add domain boundary if available
+        if hasattr(domain, 'boundary') and domain.boundary is not None:
+            self.domain_actor = self.plotter.add_mesh(
+                domain.boundary,
+                color='lightblue',
+                opacity=0.3,
+                show_edges=True,
+                edge_color='gray',
+                name='domain'
+            )
+
+        # Reset camera to show full domain
+        self.plotter.reset_camera()
+        self.plotter.render()
+
+    def add_start_point(self, point, index=None, color='red'):
+        """
+        Add a start point marker to the visualization.
+
+        Parameters
+        ----------
+        point : array-like
+            3D coordinates of the point [x, y, z]
+        index : int, optional
+            Index/label for the point
+        color : str, optional
+            Color of the point marker
+
+        Returns
+        -------
+        actor
+            PyVista actor for the point
+        """
+        point = np.asarray(point).flatten()
+
+        # Create sphere marker
+        sphere = self._pv.Sphere(radius=self._get_marker_size(), center=point)
+        actor = self.plotter.add_mesh(
+            sphere,
+            color=color,
+            name=f'start_point_{len(self.points_actors)}'
+        )
+
+        # Add label if index provided
+        if index is not None:
+            self.plotter.add_point_labels(
+                [point],
+                [f'P{index}'],
+                point_size=10,
+                font_size=12,
+                text_color='black',
+                name=f'label_{len(self.points_actors)}'
+            )
+
+        self.points_actors.append(actor)
+        self.plotter.render()
+        return actor
+
+    def add_direction(self, point, direction, length=None, color='blue'):
+        """
+        Add a direction vector visualization.
+
+        Parameters
+        ----------
+        point : array-like
+            Starting point [x, y, z]
+        direction : array-like
+            Direction vector [dx, dy, dz]
+        length : float, optional
+            Length of the arrow. If None, uses domain characteristic length
+        color : str, optional
+            Color of the arrow
+
+        Returns
+        -------
+        actor
+            PyVista actor for the direction arrow
+        """
+        point = np.asarray(point).flatten()
+        direction = np.asarray(direction).flatten()
+        direction = direction / np.linalg.norm(direction)
+
+        if length is None:
+            length = self._get_arrow_length()
+
+        # Create arrow
+        end_point = point + direction * length
+        arrow = self._pv.Line(point, end_point)
+
+        actor = self.plotter.add_mesh(
+            arrow,
+            color=color,
+            line_width=3,
+            name=f'direction_{len(self.direction_actors)}'
+        )
+
+        # Add arrow head
+        cone_height = length * 0.15
+        cone = self._pv.Cone(
+            center=end_point,
+            direction=direction,
+            height=cone_height,
+            radius=cone_height * 0.5
+        )
+        cone_actor = self.plotter.add_mesh(
+            cone,
+            color=color,
+            name=f'direction_cone_{len(self.direction_actors)}'
+        )
+
+        self.direction_actors.append((actor, cone_actor))
+        self.plotter.render()
+        return actor
+
+    def add_tree(self, tree, color='red'):
+        """
+        Add a Tree visualization.
+
+        Parameters
+        ----------
+        tree : svv.tree.Tree
+            Tree object to visualize
+        color : str, optional
+            Color for the tree vessels
+
+        Returns
+        -------
+        list
+            List of actors for the tree vessels
+        """
+        actors = []
+        for i in range(tree.data.shape[0]):
+            center = (tree.data[i, 0:3] + tree.data[i, 3:6]) / 2
+            direction = tree.data.get('w_basis', i)
+            radius = tree.data.get('radius', i)
+            length = tree.data.get('length', i)
+
+            vessel = self._pv.Cylinder(
+                center=center,
+                direction=direction,
+                radius=radius,
+                height=length
+            )
+            actor = self.plotter.add_mesh(
+                vessel,
+                color=color,
+                name=f'tree_vessel_{i}'
+            )
+            actors.append(actor)
+
+        self.tree_actors.extend(actors)
+        self.plotter.render()
+        return actors
+
+    def clear_points(self):
+        """Clear all start point markers."""
+        for actor in self.points_actors:
+            self.plotter.remove_actor(actor)
+        self.points_actors.clear()
+        self.plotter.render()
+
+    def clear_directions(self):
+        """Clear all direction arrows."""
+        for actor_tuple in self.direction_actors:
+            for actor in actor_tuple:
+                self.plotter.remove_actor(actor)
+        self.direction_actors.clear()
+        self.plotter.render()
+
+    def clear_trees(self):
+        """Clear all tree visualizations."""
+        for actor in self.tree_actors:
+            self.plotter.remove_actor(actor)
+        self.tree_actors.clear()
+        self.plotter.render()
+
+    def clear(self):
+        """Clear all visualizations except the domain."""
+        self.clear_points()
+        self.clear_directions()
+        self.clear_trees()
+
+    def reset_camera(self):
+        """Reset the camera to show the full domain."""
+        self.plotter.reset_camera()
+        self.plotter.render()
+
+    def toggle_domain_visibility(self):
+        """Toggle the visibility of the domain mesh."""
+        if self.domain_actor is not None:
+            self.domain_actor.SetVisibility(not self.domain_actor.GetVisibility())
+            self.plotter.render()
+
+    def _on_point_picked(self, point):
+        """
+        Callback for point picking.
+
+        Parameters
+        ----------
+        point : array-like
+            Picked point coordinates
+        """
+        self.point_picked.emit(np.asarray(point))
+
+    def _get_marker_size(self):
+        """
+        Calculate appropriate marker size based on domain size.
+
+        Returns
+        -------
+        float
+            Marker radius
+        """
+        if self.domain is not None and hasattr(self.domain, 'characteristic_length'):
+            return self.domain.characteristic_length * 0.05
+        return 0.1
+
+    def _get_arrow_length(self):
+        """
+        Calculate appropriate arrow length based on domain size.
+
+        Returns
+        -------
+        float
+            Arrow length
+        """
+        if self.domain is not None and hasattr(self.domain, 'characteristic_length'):
+            return self.domain.characteristic_length * 0.2
+        return 1.0


### PR DESCRIPTION
  ## Current situation

  - No specific upstream issue or PR linked. This contributes 8 commits ahead of upstream/
  main introducing the interactive GUI, .dmn persistence, sphere refinement, and related
  build/doc updates.
  - If there is a preferred tracking issue or discussion, I can link and consolidate this
  work accordingly.

  ## Release Notes

  - Feature: Interactive GUI for domain visualization using PySide6 + VTK, with point
  selection and parameter panel.
      - Entry points: python -m svv.visualize.gui and svv.visualize.gui.launch_gui(...).
      - Script: launch_gui.sh supports system OpenGL and OSMesa modes.
  - Feature: Domain persistence via .dmn with patch reconstruction and normals (svv/domain/
  io/dmn.py).
  - Feature: Sphere refinement utility (svv/utils/remeshing/remesh.py).
  - Build: External builds made opt‑in and solver fetch stabilized (setup.py).
  - Docs: API index refreshed and docs updates for navigation and quickstart.
  - Scripts: install_mesa.sh to install Mesa for headless/non‑OpenGL environments.
  - Potential behavior change: Updated defaults in svv/domain/domain.py to nobisect=True
  and order=1 (linear tetrahedra, avoid surface modifications by default).
  - Migration notes:
      - If pipelines rely on bisecting or higher‑order elements by default, explicitly set
  nobisect=False and/or order=2.
      - Re‑generate meshes in workflows that assume the previous defaults for numerical
  parity.

  ## Documentation

  - Added usage and requirements in svv/visualize/gui/README.md.
  - Updated HTML documentation pages for API navigation and quickstart.
  - Follow‑ups suggested:
      - Add “GUI usage” and troubleshooting section (headless/remote, Mesa, OSMesa) to the
  official docs site.

  ## Testing

  - Unit tests exist in test/ and svv/tests/. Pure‑Python tests should run; solver‑based
  tests require pysvzerod and associated binaries. Some boundary utilities may require
  boundary_layer.
  - CI suggestions:
      - Add a GitHub Actions workflow to run pytest for pure‑Python modules across Python
  3.9–3.12.
      - Gate GUI import smoke tests behind environment guards to skip when OpenGL/VTK isn’t
  present.
      - Optionally add a separate workflow that builds pysvzerod to exercise solver tests.

  ## Code of Conduct & Contributing Guidelines

  - [x] I agree to follow the Code of Conduct and Contributing Guidelines.
