### PR TITLE
build_ext: avoid in-place extension build for svv-accelerated

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -425,7 +425,10 @@ class DownloadAndBuildExt(build_ext):
 
     def finalize_options(self):
         super().finalize_options()
-        self.inplace = True
+        # Don't build extensions in-place for the companion binary wheel,
+        # since its package subdirectories (svv_accel/...) do not exist in
+        # the source tree. Use the default build/lib placement instead.
+        self.inplace = (not ACCEL_COMPANION)
 
 def get_extra_compile_args():
     extra_args = []


### PR DESCRIPTION
do not use in-place builds for macOS-latest or it'll prompt a missing package dirs on macOS; use build/lib placement

## Code of Conduct & Contributing Guidelines 
- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
