### PR TITLE
Fix Windows 0D solver packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,5 +27,7 @@ recursive-include svv/bin *
 # Include GUI assets (theme tokens, icons, etc.)
 recursive-include svv/visualize/gui *.json *.qss *.png *.svg
 
-# Exclude any compiled extension artifacts from source distribution
-global-exclude *.so *.pyd *.dylib *.dll
+# Exclude Python compiled extension artifacts from source distribution.
+# Do not exclude .dll globally: Windows solver builds may need runtime DLLs
+# beside svzerodsolver.exe.
+global-exclude *.so *.pyd *.dylib

--- a/setup.py
+++ b/setup.py
@@ -365,6 +365,27 @@ def build_mmg(num_cores=None):
     remove_directory_tree(source_extract_root)
 
 
+def _copy_windows_runtime_dlls(executable_path, destination_dir):
+    """
+    Copy DLLs that live next to a Windows executable into the package staging dir.
+
+    svZeroDSolver Windows builds can place runtime DLLs beside the executable.
+    Shipping only the .exe leaves an installed solver that exists on disk but
+    cannot be started by CreateProcess.
+    """
+    if platform.system() != "Windows":
+        return []
+
+    src_dir = Path(executable_path).resolve().parent
+    dst_dir = Path(destination_dir)
+    copied = []
+    for dll in sorted(src_dir.glob("*.dll")):
+        dst = dst_dir / dll.name
+        shutil.copy2(dll, dst)
+        copied.append(str(dst))
+    return copied
+
+
 def build_0d(num_cores=None):
     if num_cores is None:
         num_cores = os.cpu_count() or 1
@@ -486,6 +507,7 @@ def build_0d(num_cores=None):
     src = candidates_sorted[0]
     dst = os.path.join(install_prefix, expected_name)
     shutil.copy2(src, dst)
+    copied_dlls = _copy_windows_runtime_dlls(src, install_prefix)
     if os.name != "nt":
         try:
             mode = os.stat(dst).st_mode
@@ -493,6 +515,8 @@ def build_0d(num_cores=None):
         except Exception:
             pass
     print(f"Staged svZeroDSolver executable: {dst}")
+    for dll in copied_dlls:
+        print(f"Staged svZeroDSolver runtime DLL: {dll}")
 
     remove_directory_tree(install_tmp_prefix)
     if os.path.isfile(tarball_path_0d):
@@ -906,7 +930,7 @@ setup_info = dict(
         else {}
     ),
     exclude_package_data=(
-        {"svv": ["*.so", "*.pyd", "*.dylib", "*.dll"]} if not ACCEL_COMPANION else {}
+        {"svv": ["*.so", "*.pyd", "*.dylib"]} if not ACCEL_COMPANION else {}
     ),
     include_package_data=False,
     zip_safe=False,

--- a/svv/utils/solvers/solver_0d.py
+++ b/svv/utils/solvers/solver_0d.py
@@ -43,8 +43,9 @@ def _norm_arch(machine: Optional[str] = None) -> str:
     return m or "unknown"
 
 
-def _solver_0d_exe_filename() -> str:
-    if os.name == "nt":
+def _solver_0d_exe_filename(os_dir: Optional[str] = None) -> str:
+    os_dir = os_dir or _norm_os_dir()
+    if os_dir == "Windows":
         return SOLVER_0D_EXE_BASENAME + ".exe"
     return SOLVER_0D_EXE_BASENAME
 
@@ -147,10 +148,11 @@ def get_solver_0d_candidates(
     Search order:
     1) SVV_SOLVER_0D_PATH (explicit executable)
     2) SVV_SOLVER_0D_DIR/<exe>
-    3) svv/bin/<exe> (locally built override)
-    4) bundled: svv/utils/solvers/0D/<OS>/<arch>/<exe>
-    5) bundled fallbacks (mac): universal2 -> arch aliases
-    6) legacy fallback: svv/solvers/<exe>
+    3) PATH lookup for <exe>
+    4) svv/bin/<exe> (locally built override)
+    5) bundled: svv/utils/solvers/0D/<OS>/<arch>/<exe>
+    6) bundled fallbacks (mac): universal2 -> arch aliases
+    7) legacy fallback: svv/solvers/<exe>
     """
     os_dir = os_dir or _norm_os_dir()
     arch_override = os.environ.get("SVV_SOLVER_0D_ARCH")
@@ -166,7 +168,7 @@ def get_solver_0d_candidates(
         elif a in {"universal2"}:
             arch = "universal2"
 
-    exe_name = _solver_0d_exe_filename()
+    exe_name = _solver_0d_exe_filename(os_dir)
     solvers_dir = Path(__file__).resolve().parent / "0D"
 
     candidates: List[Path] = []
@@ -178,6 +180,10 @@ def get_solver_0d_candidates(
     solver_dir = os.environ.get("SVV_SOLVER_0D_DIR")
     if solver_dir:
         candidates.append(Path(solver_dir).expanduser() / exe_name)
+
+    path_solver = shutil.which(exe_name)
+    if path_solver:
+        candidates.append(Path(path_solver))
 
     try:
         import svv

--- a/test/test_solver_0d_selector.py
+++ b/test/test_solver_0d_selector.py
@@ -10,7 +10,13 @@ def _exe_name() -> str:
 
 def test_solver_0d_candidates_include_platform_arch_layout():
     sel = get_solver_0d_candidates(os_dir="Linux", arch="x86_64")
-    expected_suffix = Path("svv") / "utils" / "solvers" / "0D" / "Linux" / "x86_64" / _exe_name()
+    expected_suffix = Path("svv") / "utils" / "solvers" / "0D" / "Linux" / "x86_64" / "svzerodsolver"
+    assert any(str(p).endswith(str(expected_suffix)) for p in sel.candidates)
+
+
+def test_solver_0d_candidates_use_windows_exe_suffix():
+    sel = get_solver_0d_candidates(os_dir="Windows", arch="x86_64")
+    expected_suffix = Path("svv") / "utils" / "solvers" / "0D" / "Windows" / "x86_64" / "svzerodsolver.exe"
     assert any(str(p).endswith(str(expected_suffix)) for p in sel.candidates)
 
 
@@ -31,6 +37,19 @@ def test_get_solver_0d_exe_from_env_dir(monkeypatch, tmp_path):
 
     monkeypatch.delenv("SVV_SOLVER_0D_PATH", raising=False)
     monkeypatch.setenv("SVV_SOLVER_0D_DIR", str(tmp_path))
+
+    resolved = get_solver_0d_exe()
+    assert resolved == exe
+
+
+def test_get_solver_0d_exe_from_path(monkeypatch, tmp_path):
+    exe = tmp_path / _exe_name()
+    exe.write_bytes(b"#!/bin/sh\n")
+    exe.chmod(0o755)
+
+    monkeypatch.delenv("SVV_SOLVER_0D_PATH", raising=False)
+    monkeypatch.delenv("SVV_SOLVER_0D_DIR", raising=False)
+    monkeypatch.setenv("PATH", str(tmp_path))
 
     resolved = get_solver_0d_exe()
     assert resolved == exe


### PR DESCRIPTION
## Summary

Fixes #53.

This updates the Windows 0D solver packaging path so `svzerodsolver.exe` is not packaged without required sibling runtime DLLs. Windows builds can emit `.dll` files beside the solver executable, and those files need to remain beside the executable after installation.

Changes include:

- copy sibling Windows runtime DLLs when staging `svzerodsolver.exe`
- stop globally excluding `.dll` files from package data/source distributions
- use the target OS when selecting the 0D solver executable suffix
- add PATH-based solver discovery for installed `svzerodsolver`
- add regression coverage for Windows solver selection behavior

## Validation

- `pytest -q test/test_solver_0d_selector.py test/test_zerod_export_solver_opt_in.py`
  - `7 passed`
- `git diff --check`
  - passed
- `python setup.py egg_info`
  - passed
- `python setup.py bdist_wheel`
  - passed

## Notes

This has not yet been validated on a Windows/Conda machine, so the exact DLL set produced by the Windows `svZeroDSolver` build should still be confirmed there.
