### PR TITLE
Fix 0D solver output path handling

### DIFF
--- a/svv/simulation/fluid/rom/zero_d/process.py
+++ b/svv/simulation/fluid/rom/zero_d/process.py
@@ -1,3 +1,6 @@
+DEFAULT_OUTPUT_FILENAME = "output.csv"
+
+
 run_0d_script = """import atexit
 import os
 import signal
@@ -6,6 +9,7 @@ import sys
 
 PINNED_SOLVER = {solver_exe!r}
 INPUT_FILENAME = {input_filename!r}
+OUTPUT_FILENAME = {output_filename!r}
 CHILD_PID_FILE = ".svv_0d_solver.pid"
 _CHILD_PROCESS = None
 
@@ -98,6 +102,7 @@ def _handle_signal(signum, _frame):
 def main():
     run_dir = os.path.dirname(os.path.abspath(__file__))
     input_file = os.path.join(run_dir, INPUT_FILENAME)
+    output_file = os.path.join(run_dir, OUTPUT_FILENAME)
     if not os.path.isfile(input_file):
         print("Input file not found: " + input_file, file=sys.stderr, flush=True)
         sys.exit(2)
@@ -114,8 +119,9 @@ def main():
     atexit.register(_stop_child, run_dir, False)
 
     print("Running svZeroDSolver: " + solver, flush=True)
+    print("Writing solver output: " + output_file, flush=True)
     global _CHILD_PROCESS
-    _CHILD_PROCESS = subprocess.Popen([solver, input_file], cwd=run_dir)
+    _CHILD_PROCESS = subprocess.Popen([solver, input_file, output_file], cwd=run_dir)
     _write_child_pid(run_dir, _CHILD_PROCESS.pid)
     try:
         return_code = _CHILD_PROCESS.wait()

--- a/svv/simulation/fluid/rom/zero_d/zerod_forest.py
+++ b/svv/simulation/fluid/rom/zero_d/zerod_forest.py
@@ -3,7 +3,7 @@ import numpy as np
 import json
 import platform
 from svv.simulation.fluid.rom.zero_d.post import make_results, view_plots, post_data, collate_timeseries_to_pvd
-from svv.simulation.fluid.rom.zero_d.process import run_0d_script
+from svv.simulation.fluid.rom.zero_d.process import DEFAULT_OUTPUT_FILENAME, run_0d_script
 from svv.simulation.fluid.inflow.waveform import generate_physiologic_wave
 from svv.utils.solvers.solver_0d import get_solver_0d_exe
 
@@ -309,8 +309,26 @@ def export_0d_simulation(forest, network_id, inlets, steady=True, outdir=None, f
         if resolved_solver_0d is not None:
             cmd_file = outdir + os.sep + ("cmd_run.bat" if platform.system() == "Windows" else "cmd_run.bash")
             with open(cmd_file, "w") as cmd:
-                cmd.write(f"\"{resolved_solver_0d}\" \"solver_0d.in\"")
-        file.write(run_0d_script.format(solver_exe=resolved_solver_0d, input_filename="solver_0d.in"))
+                if platform.system() == "Windows":
+                    cmd.write(
+                        "@echo off\n"
+                        "cd /d \"%~dp0\"\n"
+                        f"\"{resolved_solver_0d}\" \"solver_0d.in\" \"{DEFAULT_OUTPUT_FILENAME}\"\n"
+                    )
+                else:
+                    cmd.write(
+                        "#!/usr/bin/env bash\n"
+                        "set -e\n"
+                        "cd \"$(dirname \"$0\")\"\n"
+                        f"\"{resolved_solver_0d}\" \"solver_0d.in\" \"{DEFAULT_OUTPUT_FILENAME}\"\n"
+                    )
+        file.write(
+            run_0d_script.format(
+                solver_exe=resolved_solver_0d,
+                input_filename="solver_0d.in",
+                output_filename=DEFAULT_OUTPUT_FILENAME,
+            )
+        )
     file.close()
     # DETERMINE NUMBER OF ROWS FOR GEOM
     geoms = np.zeros((vessels['proximal_points'].shape[0], 8))

--- a/svv/simulation/fluid/rom/zero_d/zerod_tree.py
+++ b/svv/simulation/fluid/rom/zero_d/zerod_tree.py
@@ -9,7 +9,7 @@ from svv.simulation.fluid.rom.zero_d.post import (
     post_data,
     view_plots,
 )
-from svv.simulation.fluid.rom.zero_d.process import run_0d_script
+from svv.simulation.fluid.rom.zero_d.process import DEFAULT_OUTPUT_FILENAME, run_0d_script
 from svv.utils.solvers.solver_0d import get_solver_0d_exe
 
 def export_0d_simulation(tree ,steady=True ,outdir=None ,folder="0d_tmp" ,number_cardiac_cycles=1,flow=None,
@@ -252,8 +252,26 @@ def export_0d_simulation(tree ,steady=True ,outdir=None ,folder="0d_tmp" ,number
         if resolved_solver_0d is not None:
             cmd_file = outdir + os.sep + ("cmd_run.bat" if platform.system() == "Windows" else "cmd_run.bash")
             with open(cmd_file, "w") as cmd:
-                cmd.write(f"\"{resolved_solver_0d}\" \"{filename}\"")
-        file.write(run_0d_script.format(solver_exe=resolved_solver_0d, input_filename=filename))
+                if platform.system() == "Windows":
+                    cmd.write(
+                        "@echo off\n"
+                        "cd /d \"%~dp0\"\n"
+                        f"\"{resolved_solver_0d}\" \"{filename}\" \"{DEFAULT_OUTPUT_FILENAME}\"\n"
+                    )
+                else:
+                    cmd.write(
+                        "#!/usr/bin/env bash\n"
+                        "set -e\n"
+                        "cd \"$(dirname \"$0\")\"\n"
+                        f"\"{resolved_solver_0d}\" \"{filename}\" \"{DEFAULT_OUTPUT_FILENAME}\"\n"
+                    )
+        file.write(
+            run_0d_script.format(
+                solver_exe=resolved_solver_0d,
+                input_filename=filename,
+                output_filename=DEFAULT_OUTPUT_FILENAME,
+            )
+        )
     file.close()
 
     geom = np.zeros((tree.data.shape[0], 8))

--- a/test/test_zerod_export_solver_opt_in.py
+++ b/test/test_zerod_export_solver_opt_in.py
@@ -44,7 +44,29 @@ def test_tree_0d_export_does_not_probe_solver_when_not_requested(monkeypatch, tm
     plot_text = (outdir / "plot_0d_results_to_3d.py").read_text(encoding="utf-8")
     assert "CHILD_PID_FILE" in run_text
     assert "signal.signal" in run_text
+    assert "OUTPUT_FILENAME" in run_text
     assert "SVV_0D_DISABLE_TQDM" in plot_text
+
+
+def test_tree_0d_export_command_file_runs_from_export_dir(monkeypatch, tmp_path):
+    tree = SimpleNamespace(
+        data=_base_tree_data(),
+        parameters=SimpleNamespace(terminal_pressure=100.0, kinematic_viscosity=0.04),
+    )
+    solver = tmp_path / "svzerodsolver.exe"
+    solver.write_text("", encoding="utf-8")
+    monkeypatch.setattr(zerod_tree.platform, "system", lambda: "Windows")
+
+    zerod_tree.export_0d_simulation(
+        tree,
+        outdir=str(tmp_path),
+        folder="case",
+        path_to_0d_solver=str(solver),
+    )
+
+    cmd_text = (tmp_path / "case" / "cmd_run.bat").read_text(encoding="utf-8")
+    assert 'cd /d "%~dp0"' in cmd_text
+    assert '"solver_0d.in" "output.csv"' in cmd_text
 
 
 def test_forest_0d_export_does_not_probe_solver_when_not_requested(monkeypatch, tmp_path):
@@ -76,3 +98,4 @@ def test_forest_0d_export_does_not_probe_solver_when_not_requested(monkeypatch, 
     assert not (outdir / "cmd_run.bash").exists()
     run_text = (outdir / "run.py").read_text(encoding="utf-8")
     assert "CHILD_PID_FILE" in run_text
+    assert "OUTPUT_FILENAME" in run_text

--- a/test/test_zerod_run_script_paths.py
+++ b/test/test_zerod_run_script_paths.py
@@ -1,0 +1,72 @@
+import json
+import os
+import shlex
+import stat
+import subprocess
+import sys
+
+from svv.simulation.fluid.rom.zero_d.process import DEFAULT_OUTPUT_FILENAME, run_0d_script
+
+
+def _write_fake_solver(tmp_path):
+    impl = tmp_path / "fake_solver_impl.py"
+    impl.write_text(
+        "\n".join(
+            [
+                "import json",
+                "import os",
+                "import sys",
+                "",
+                "payload = {'argv': sys.argv[1:], 'cwd': os.getcwd()}",
+                "with open(os.path.join(os.getcwd(), 'solver_invocation.json'), 'w', encoding='utf-8') as handle:",
+                "    json.dump(payload, handle)",
+                "with open(sys.argv[2], 'w', encoding='utf-8') as handle:",
+                "    handle.write('name,time,flow_in,flow_out,pressure_in,pressure_out\\n')",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    if os.name == "nt":
+        solver = tmp_path / "fake_solver.bat"
+        solver.write_text(f'@echo off\n"{sys.executable}" "{impl}" %*\n', encoding="utf-8")
+        return solver
+
+    solver = tmp_path / "fake_solver"
+    solver.write_text(
+        "#!/usr/bin/env sh\n"
+        f"exec {shlex.quote(sys.executable)} {shlex.quote(str(impl))} \"$@\"\n",
+        encoding="utf-8",
+    )
+    solver.chmod(solver.stat().st_mode | stat.S_IXUSR)
+    return solver
+
+
+def test_generated_run_script_writes_output_next_to_script_when_launched_elsewhere(tmp_path):
+    export_dir = tmp_path / "case"
+    launch_dir = tmp_path / "elsewhere"
+    export_dir.mkdir()
+    launch_dir.mkdir()
+
+    solver = _write_fake_solver(tmp_path)
+    input_path = export_dir / "solver_0d.in"
+    output_path = export_dir / DEFAULT_OUTPUT_FILENAME
+    input_path.write_text("{}", encoding="utf-8")
+    (export_dir / "run.py").write_text(
+        run_0d_script.format(
+            solver_exe=str(solver),
+            input_filename=input_path.name,
+            output_filename=DEFAULT_OUTPUT_FILENAME,
+        ),
+        encoding="utf-8",
+    )
+
+    subprocess.check_call([sys.executable, str(export_dir / "run.py")], cwd=launch_dir)
+
+    assert output_path.is_file()
+    assert not (launch_dir / DEFAULT_OUTPUT_FILENAME).exists()
+
+    payload = json.loads((export_dir / "solver_invocation.json").read_text(encoding="utf-8"))
+    assert payload["cwd"] == str(export_dir)
+    assert payload["argv"] == [str(input_path), str(output_path)]


### PR DESCRIPTION
## Summary

Fixes #69.

This updates the generated 0D solver runner and helper scripts so solver output is written explicitly to `output.csv` in the exported simulation directory. On Windows, relying on the solver's default output-path behavior can result in the solver reporting `/output.csv`, after which the generated postprocessing script fails because `output.csv` is not present beside the exported files.

Changes include:

- pass an explicit `output.csv` path to `svzerodsolver` from the generated `run.py`
- log the resolved solver output path before launching the solver
- update generated `cmd_run.bat` and `cmd_run.bash` helpers to run from their own export directory
- pass the explicit output filename in the command helper scripts
- add regression coverage for generated 0D runner/output path behavior
- update existing 0D export tests to check the generated output-path arguments

## Validation

- `python -m pytest test/test_zerod_export_solver_opt_in.py test/test_zerod_run_script_paths.py test/test_solver_0d_selector.py -q`
  - `9 passed`

## Notes

This has not yet been validated with a native Windows `svZeroDSolver` binary in this environment. The regression coverage verifies that generated scripts now pass explicit input and output paths, which avoids the Windows default-output path issue reported here.
