### PR TITLE
Automate PyPI version bumps in the release workflow

### DIFF
--- a/.github/scripts/release_version.py
+++ b/.github/scripts/release_version.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Calculate release versions and validate release artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tarfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from email.parser import BytesParser
+from pathlib import Path
+
+
+VERSION_FILE_DEFAULT = Path("svv/__init__.py")
+SUPPORTED_PROJECTS = {"svv", "svv-accelerated"}
+VERSION_ASSIGNMENT = re.compile(
+    r"^(?P<prefix>__version__\s*=\s*)(?P<quote>['\"])(?P<version>[^'\"]+)"
+    r"(?P=quote)(?P<trailing>[ \t]*)$",
+    re.MULTILINE,
+)
+RELEASE_VERSION = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")
+
+
+class ReleaseVersionError(RuntimeError):
+    """Raised when release version data is invalid or inconsistent."""
+
+
+@dataclass(frozen=True)
+class Artifact:
+    path: Path
+    project: str
+    version: str
+    kind: str
+
+
+def _version_match(version: str) -> re.Match[str]:
+    match = RELEASE_VERSION.fullmatch(version)
+    if match is None:
+        raise ReleaseVersionError(
+            f"Expected a three-component numeric version, found {version!r}"
+        )
+    return match
+
+
+def read_version(path: Path = VERSION_FILE_DEFAULT) -> str:
+    text = path.read_text(encoding="utf-8")
+    matches = list(VERSION_ASSIGNMENT.finditer(text))
+    if len(matches) != 1:
+        raise ReleaseVersionError(
+            f"Expected exactly one __version__ assignment in {path}, found {len(matches)}"
+        )
+    version = matches[0].group("version")
+    _version_match(version)
+    return version
+
+
+def bump_version(version: str, part: str) -> str:
+    match = _version_match(version)
+    major = int(match.group("major"))
+    minor = int(match.group("minor"))
+    patch = int(match.group("patch"))
+
+    if part == "major":
+        return f"{major + 1}.0.0"
+    if part == "minor":
+        return f"{major}.{minor + 1}.0"
+    if part == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    raise ReleaseVersionError(f"Unsupported version increment: {part!r}")
+
+
+def write_version(
+    path: Path,
+    version: str,
+    *,
+    expected_current: str | None = None,
+) -> None:
+    _version_match(version)
+    text = path.read_text(encoding="utf-8")
+    matches = list(VERSION_ASSIGNMENT.finditer(text))
+    if len(matches) != 1:
+        raise ReleaseVersionError(
+            f"Expected exactly one __version__ assignment in {path}, found {len(matches)}"
+        )
+
+    match = matches[0]
+    current = match.group("version")
+    _version_match(current)
+    if expected_current is not None and current != expected_current:
+        raise ReleaseVersionError(
+            f"Expected {path} to contain version {expected_current}, found {current}"
+        )
+
+    updated = text[: match.start("version")] + version + text[match.end("version") :]
+    path.write_text(updated, encoding="utf-8")
+
+
+def _canonical_project_name(name: str) -> str:
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _parse_metadata(payload: bytes, source: str) -> tuple[str, str]:
+    metadata = BytesParser().parsebytes(payload)
+    name = metadata.get("Name")
+    version = metadata.get("Version")
+    if not name or not version:
+        raise ReleaseVersionError(f"Missing Name or Version metadata in {source}")
+    return _canonical_project_name(name), version
+
+
+def _runtime_version(payload: bytes, source: str) -> str:
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ReleaseVersionError(f"Unable to decode {source} as UTF-8") from exc
+    matches = list(VERSION_ASSIGNMENT.finditer(text))
+    if len(matches) != 1:
+        raise ReleaseVersionError(
+            f"Expected exactly one __version__ assignment in {source}, found {len(matches)}"
+        )
+    return matches[0].group("version")
+
+
+def _inspect_wheel(path: Path) -> Artifact:
+    with zipfile.ZipFile(path) as archive:
+        metadata_files = [
+            name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_files) != 1:
+            raise ReleaseVersionError(
+                f"Expected one METADATA file in {path.name}, found {len(metadata_files)}"
+            )
+        project, version = _parse_metadata(
+            archive.read(metadata_files[0]), f"{path.name}:{metadata_files[0]}"
+        )
+        if project == "svv":
+            init_name = "svv/__init__.py"
+            if init_name not in archive.namelist():
+                raise ReleaseVersionError(f"Missing {init_name} in {path.name}")
+            runtime_version = _runtime_version(
+                archive.read(init_name), f"{path.name}:{init_name}"
+            )
+            if runtime_version != version:
+                raise ReleaseVersionError(
+                    f"Runtime version {runtime_version} does not match metadata version "
+                    f"{version} in {path.name}"
+                )
+    return Artifact(path=path, project=project, version=version, kind="wheel")
+
+
+def _inspect_sdist(path: Path) -> Artifact:
+    with tarfile.open(path, mode="r:gz") as archive:
+        files = [member for member in archive.getmembers() if member.isfile()]
+        metadata_files = [
+            member for member in files if member.name.endswith("/PKG-INFO")
+        ]
+        if not metadata_files:
+            raise ReleaseVersionError(f"Missing PKG-INFO in {path.name}")
+        metadata_member = min(metadata_files, key=lambda member: member.name.count("/"))
+        metadata_stream = archive.extractfile(metadata_member)
+        if metadata_stream is None:
+            raise ReleaseVersionError(
+                f"Unable to read {metadata_member.name} from {path.name}"
+            )
+        project, version = _parse_metadata(
+            metadata_stream.read(), f"{path.name}:{metadata_member.name}"
+        )
+        if project == "svv":
+            init_files = [
+                member for member in files if member.name.endswith("/svv/__init__.py")
+            ]
+            if len(init_files) != 1:
+                raise ReleaseVersionError(
+                    f"Expected one svv/__init__.py in {path.name}, found {len(init_files)}"
+                )
+            init_stream = archive.extractfile(init_files[0])
+            if init_stream is None:
+                raise ReleaseVersionError(
+                    f"Unable to read {init_files[0].name} from {path.name}"
+                )
+            runtime_version = _runtime_version(
+                init_stream.read(), f"{path.name}:{init_files[0].name}"
+            )
+            if runtime_version != version:
+                raise ReleaseVersionError(
+                    f"Runtime version {runtime_version} does not match metadata version "
+                    f"{version} in {path.name}"
+                )
+    return Artifact(path=path, project=project, version=version, kind="sdist")
+
+
+def inspect_artifacts(dist_dir: Path, expected_version: str) -> list[Artifact]:
+    _version_match(expected_version)
+    paths = sorted([*dist_dir.glob("*.whl"), *dist_dir.glob("*.tar.gz")])
+    if not paths:
+        raise ReleaseVersionError(f"No wheel or source artifacts found in {dist_dir}")
+
+    artifacts: list[Artifact] = []
+    for path in paths:
+        artifact = (
+            _inspect_wheel(path) if path.suffix == ".whl" else _inspect_sdist(path)
+        )
+        if artifact.project not in SUPPORTED_PROJECTS:
+            raise ReleaseVersionError(
+                f"Unexpected project {artifact.project!r} in {artifact.path.name}"
+            )
+        if artifact.version != expected_version:
+            raise ReleaseVersionError(
+                f"Expected version {expected_version}, found {artifact.version} in "
+                f"{artifact.path.name}"
+            )
+        artifacts.append(artifact)
+
+    required = {
+        ("svv", "wheel"),
+        ("svv", "sdist"),
+        ("svv-accelerated", "wheel"),
+    }
+    present = {(artifact.project, artifact.kind) for artifact in artifacts}
+    missing = sorted(required - present)
+    if missing:
+        formatted = ", ".join(f"{project} {kind}" for project, kind in missing)
+        raise ReleaseVersionError(f"Missing required release artifacts: {formatted}")
+    return artifacts
+
+
+def _fetch_pypi_files(project: str, version: str) -> set[str]:
+    encoded_project = urllib.parse.quote(project, safe="")
+    encoded_version = urllib.parse.quote(version, safe="")
+    url = f"https://pypi.org/pypi/{encoded_project}/{encoded_version}/json"
+    request = urllib.request.Request(
+        url, headers={"User-Agent": "svv-release-workflow"}
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return set()
+        raise ReleaseVersionError(
+            f"PyPI returned HTTP {exc.code} for {project} {version}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise ReleaseVersionError(
+            f"Unable to query PyPI for {project} {version}: {exc.reason}"
+        ) from exc
+    return {item["filename"] for item in payload.get("urls", []) if "filename" in item}
+
+
+def verify_pypi(
+    dist_dir: Path,
+    expected_version: str,
+    *,
+    attempts: int = 12,
+    delay: float = 5.0,
+) -> None:
+    if attempts < 1:
+        raise ReleaseVersionError("PyPI verification attempts must be at least 1")
+    artifacts = inspect_artifacts(dist_dir, expected_version)
+    expected: dict[str, set[str]] = {project: set() for project in SUPPORTED_PROJECTS}
+    for artifact in artifacts:
+        expected[artifact.project].add(artifact.path.name)
+
+    last_details = ""
+    for attempt in range(1, attempts + 1):
+        problems: list[str] = []
+        for project in sorted(expected):
+            try:
+                published = _fetch_pypi_files(project, expected_version)
+            except ReleaseVersionError as exc:
+                problems.append(str(exc))
+                continue
+            missing = sorted(expected[project] - published)
+            if missing:
+                problems.append(f"{project} missing: {', '.join(missing)}")
+        if not problems:
+            return
+        last_details = "; ".join(problems)
+        if attempt < attempts:
+            print(
+                f"PyPI verification attempt {attempt}/{attempts} incomplete: "
+                f"{last_details}",
+                flush=True,
+            )
+            time.sleep(delay)
+
+    raise ReleaseVersionError(
+        f"PyPI does not contain every expected {expected_version} artifact after "
+        f"{attempts} attempts: {last_details}"
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    current = subparsers.add_parser("current", help="Print the current source version")
+    current.add_argument("--path", type=Path, default=VERSION_FILE_DEFAULT)
+
+    next_version = subparsers.add_parser("next", help="Print the next release version")
+    next_version.add_argument("--path", type=Path, default=VERSION_FILE_DEFAULT)
+    next_version.add_argument(
+        "--bump", choices=("patch", "minor", "major"), required=True
+    )
+
+    set_version = subparsers.add_parser("set", help="Update the source version")
+    set_version.add_argument("--path", type=Path, default=VERSION_FILE_DEFAULT)
+    set_version.add_argument("--version", required=True)
+    set_version.add_argument("--expected-current")
+
+    verify_dist = subparsers.add_parser(
+        "verify-dist", help="Validate built artifact names and embedded versions"
+    )
+    verify_dist.add_argument("--dist", type=Path, default=Path("dist"))
+    verify_dist.add_argument("--version", required=True)
+
+    verify_index = subparsers.add_parser(
+        "verify-pypi", help="Confirm that every built artifact is available from PyPI"
+    )
+    verify_index.add_argument("--dist", type=Path, default=Path("dist"))
+    verify_index.add_argument("--version", required=True)
+    verify_index.add_argument("--attempts", type=int, default=12)
+    verify_index.add_argument("--delay", type=float, default=5.0)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.command == "current":
+            print(read_version(args.path))
+        elif args.command == "next":
+            print(bump_version(read_version(args.path), args.bump))
+        elif args.command == "set":
+            write_version(
+                args.path,
+                args.version,
+                expected_current=args.expected_current,
+            )
+            print(args.version)
+        elif args.command == "verify-dist":
+            artifacts = inspect_artifacts(args.dist, args.version)
+            print(f"Validated {len(artifacts)} release artifacts for {args.version}")
+        elif args.command == "verify-pypi":
+            verify_pypi(
+                args.dist,
+                args.version,
+                attempts=args.attempts,
+                delay=args.delay,
+            )
+            print(f"Verified all {args.version} release artifacts on PyPI")
+        else:  # pragma: no cover - argparse restricts command values
+            raise ReleaseVersionError(f"Unsupported command: {args.command}")
+    except (OSError, ReleaseVersionError, tarfile.TarError, zipfile.BadZipFile) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -3,17 +3,84 @@ name: Build & Publish to PyPI
 on:
   workflow_dispatch:
     inputs:
-      name:
-        description: "Upload to PyPi?"
+      publish:
+        description: "Upload built packages to PyPI?"
         required: true
-        default: "true"
+        default: true
+        type: boolean
+      version_bump:
+        description: "Version increment to use when publishing"
+        required: true
+        default: "patch"
         type: choice
         options:
-          - "true"
-          - "false"
+          - "patch"
+          - "minor"
+          - "major"
+
+concurrency:
+  group: pypi-release-${{ inputs.publish && 'production' || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
+  prepare_release:
+    runs-on: ubuntu-latest
+    outputs:
+      current_version: ${{ steps.version.outputs.current_version }}
+      release_version: ${{ steps.version.outputs.release_version }}
+      source_sha: ${{ steps.version.outputs.source_sha }}
+    steps:
+      - name: Require the default branch for publishing
+        if: ${{ inputs.publish && github.ref_name != github.event.repository.default_branch }}
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          echo "::error title=Invalid release branch::PyPI releases must run from ${DEFAULT_BRANCH}."
+          exit 1
+
+      - name: Check out release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.publish && github.event.repository.default_branch || github.sha }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Determine build version
+        id: version
+        shell: bash
+        env:
+          PUBLISH: ${{ inputs.publish }}
+          VERSION_BUMP: ${{ inputs.version_bump }}
+        run: |
+          set -euo pipefail
+          current_version=$(python .github/scripts/release_version.py current)
+          release_version=$current_version
+          if [[ "$PUBLISH" == "true" ]]; then
+            release_version=$(python .github/scripts/release_version.py next --bump "$VERSION_BUMP")
+          fi
+          source_sha=$(git rev-parse HEAD)
+          {
+            echo "current_version=$current_version"
+            echo "release_version=$release_version"
+            echo "source_sha=$source_sha"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "### Package build"
+            echo "- Source commit: \`$source_sha\`"
+            echo "- Source version: \`$current_version\`"
+            echo "- Build version: \`$release_version\`"
+            echo "- Publish: \`$PUBLISH\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   build_wheels_base:
+    needs: prepare_release
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -44,11 +111,22 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare_release.outputs.source_sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Set package version
+        env:
+          CURRENT_VERSION: ${{ needs.prepare_release.outputs.current_version }}
+          RELEASE_VERSION: ${{ needs.prepare_release.outputs.release_version }}
+        run: >-
+          python .github/scripts/release_version.py set
+          --expected-current "$CURRENT_VERSION"
+          --version "$RELEASE_VERSION"
 
       - name: Install cibuildwheel
         run: python -m pip install --upgrade pip && python -m pip install cibuildwheel
@@ -173,7 +251,11 @@ jobs:
           path: dist
 
   build_wheels_accelerated:
+    needs: prepare_release
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
@@ -191,6 +273,22 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare_release.outputs.source_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set package version
+        env:
+          CURRENT_VERSION: ${{ needs.prepare_release.outputs.current_version }}
+          RELEASE_VERSION: ${{ needs.prepare_release.outputs.release_version }}
+        run: >-
+          python .github/scripts/release_version.py set
+          --expected-current "$CURRENT_VERSION"
+          --version "$RELEASE_VERSION"
 
       - name: Install cibuildwheel
         run: python -m pip install --upgrade pip && pip install cibuildwheel
@@ -211,9 +309,27 @@ jobs:
           path: dist
 
   build_sdist:
+    needs: prepare_release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare_release.outputs.source_sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set package version
+        env:
+          CURRENT_VERSION: ${{ needs.prepare_release.outputs.current_version }}
+          RELEASE_VERSION: ${{ needs.prepare_release.outputs.release_version }}
+        run: >-
+          python .github/scripts/release_version.py set
+          --expected-current "$CURRENT_VERSION"
+          --version "$RELEASE_VERSION"
 
       - name: Install build dependencies
         run: |
@@ -228,11 +344,18 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [build_wheels_base, build_wheels_accelerated, build_sdist]
+    if: ${{ inputs.publish }}
+    needs: [prepare_release, build_wheels_base, build_wheels_accelerated, build_sdist]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
+      - name: Check out release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare_release.outputs.source_sha }}
+          fetch-depth: 0
+
       - uses: actions/download-artifact@v4
         with:
           # download all artifacts from previous jobs (base wheels, sdist, accelerated wheels)
@@ -240,23 +363,73 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Install build dependencies
         run: |
-          pip install --upgrade pip && pip install twine
+          python -m pip install --upgrade pip
+          python -m pip install twine
+
+      - name: Validate release artifacts
+        env:
+          RELEASE_VERSION: ${{ needs.prepare_release.outputs.release_version }}
+        run: >-
+          python .github/scripts/release_version.py verify-dist
+          --dist dist
+          --version "$RELEASE_VERSION"
+
+      - name: Validate PyPI credentials
+        env:
+          PYPI_PASSWORD_SVV: ${{ secrets.PYPI_PASSWORD_SVV }}
+          PYPI_PASSWORD_ACCEL: ${{ secrets.PYPI_PASSWORD_ACCEL }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$PYPI_PASSWORD_SVV" ]]; then
+            echo "::error title=Missing secret::The repository secret 'PYPI_PASSWORD_SVV' is not configured."
+            exit 1
+          fi
+          if [[ -z "$PYPI_PASSWORD_ACCEL" ]]; then
+            echo "::error title=Missing secret::The repository secret 'PYPI_PASSWORD_ACCEL' is not configured."
+            exit 1
+          fi
+
+      - name: Confirm release source is current
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          SOURCE_SHA: ${{ needs.prepare_release.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          remote_sha=$(git rev-parse "refs/remotes/origin/${DEFAULT_BRANCH}")
+          if [[ "$remote_sha" != "$SOURCE_SHA" ]]; then
+            echo "::error title=Release source changed::${DEFAULT_BRANCH} advanced from ${SOURCE_SHA} to ${remote_sha} while artifacts were building. Run the workflow again."
+            exit 1
+          fi
 
       - name: Upload base package (svv) to PyPI
         run: |
           set -euo pipefail
-          files=$(ls dist/svv-*.whl dist/svv-*.tar.gz 2>/dev/null | grep -v 'svv[-_]accelerated' || true)
-          if [ -z "$files" ]; then
-            echo "No base svv artifacts found; skipping upload."
-            exit 0
-          fi
-          if [ -z "${{ secrets.PYPI_PASSWORD_SVV }}" ]; then
-            echo "::error title=Missing secret::The repository secret 'PYPI_PASSWORD_SVV' is not configured. Set it to a PyPI API token with access to the 'svv' project.";
+          mapfile -t files < <(
+            find dist -maxdepth 1 -type f \
+              \( -name 'svv-*.whl' -o -name 'svv-*.tar.gz' \) \
+              ! -name 'svv-accelerated-*' \
+              ! -name 'svv_accelerated-*' \
+              -print | sort
+          )
+          if (( ${#files[@]} == 0 )); then
+            echo "::error title=Missing artifacts::No base svv artifacts were found."
             exit 1
           fi
-          twine upload --non-interactive --skip-existing --verbose --repository pypi $files
+          python -m twine upload \
+            --non-interactive \
+            --skip-existing \
+            --verbose \
+            --repository pypi \
+            "${files[@]}"
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD_SVV }}
@@ -264,44 +437,71 @@ jobs:
       - name: Upload accelerated wheels (svv-accelerated) to PyPI
         run: |
           set -euo pipefail
-          # Wheel filenames normalize '-' to '_' (PEP 427), e.g. svv_accelerated-0.0.42-...
-          files=$(ls dist/svv[-_]accelerated-*.whl 2>/dev/null || true)
-          if [ -z "$files" ]; then
-            echo "No svv-accelerated artifacts found; skipping upload."
-            exit 0
-          fi
-          if [ -z "${{ secrets.PYPI_PASSWORD_ACCEL }}" ]; then
-            echo "::error title=Missing secret::The repository secret 'PYPI_PASSWORD_ACCEL' is not configured. Set it to a PyPI API token with access to the 'svv-accelerated' project.";
+          mapfile -t files < <(
+            find dist -maxdepth 1 -type f \
+              \( -name 'svv_accelerated-*.whl' -o -name 'svv-accelerated-*.whl' \) \
+              -print | sort
+          )
+          if (( ${#files[@]} == 0 )); then
+            echo "::error title=Missing artifacts::No svv-accelerated artifacts were found."
             exit 1
           fi
-          twine upload --non-interactive --skip-existing --verbose --repository pypi $files
+          python -m twine upload \
+            --non-interactive \
+            --skip-existing \
+            --verbose \
+            --repository pypi \
+            "${files[@]}"
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD_ACCEL }}
 
-      - name: Extract version from artifacts
-        id: extract_version
+      - name: Verify published artifacts
+        env:
+          RELEASE_VERSION: ${{ needs.prepare_release.outputs.release_version }}
+        run: >-
+          python .github/scripts/release_version.py verify-pypi
+          --dist dist
+          --version "$RELEASE_VERSION"
+
+      - name: Record published version
+        id: version_commit
+        env:
+          CURRENT_VERSION: ${{ needs.prepare_release.outputs.current_version }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_VERSION: ${{ needs.prepare_release.outputs.release_version }}
+          SOURCE_SHA: ${{ needs.prepare_release.outputs.source_sha }}
         run: |
           set -euo pipefail
-          file=$(ls dist/svv-*.whl 2>/dev/null | head -n1 || true)
-          if [ -z "$file" ]; then file=$(ls dist/svv-*.tar.gz 2>/dev/null | head -n1 || true); fi
-          if [ -z "$file" ]; then
-            echo "::error title=Version detection failed::No base svv artifact found to determine version."; exit 1
+          git fetch --no-tags origin \
+            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          remote_sha=$(git rev-parse "refs/remotes/origin/${DEFAULT_BRANCH}")
+          if [[ "$remote_sha" != "$SOURCE_SHA" ]]; then
+            echo "::error title=Version commit blocked::${DEFAULT_BRANCH} changed after the upload completed. The published files are intact; reconcile ${DEFAULT_BRANCH} with version ${RELEASE_VERSION} before starting another release."
+            exit 1
           fi
-          base=$(basename "$file")
-          # Extract version after 'svv-' up to next '-'
-          version=$(echo "$base" | sed -E 's/^svv-([^\-]+).*/\1/')
-          echo "Detected version: $version"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          python .github/scripts/release_version.py set \
+            --expected-current "$CURRENT_VERSION" \
+            --version "$RELEASE_VERSION"
+          git diff --check -- svv/__init__.py
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add svv/__init__.py
+          git commit -m "chore: bump version to ${RELEASE_VERSION}"
+          commit_sha=$(git rev-parse HEAD)
+          git push origin "HEAD:refs/heads/${DEFAULT_BRANCH}"
+          echo "sha=$commit_sha" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release and upload artifacts
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.extract_version.outputs.version }}
-          name: svv ${{ steps.extract_version.outputs.version }}
+          tag_name: ${{ needs.prepare_release.outputs.release_version }}
+          name: svv ${{ needs.prepare_release.outputs.release_version }}
+          target_commitish: ${{ steps.version_commit.outputs.sha }}
           generate_release_notes: true
           draft: false
           prerelease: false
+          fail_on_unmatched_files: true
           files: |
             dist/svv-*.whl
             dist/svv-*.tar.gz


### PR DESCRIPTION
## Summary

This change removes the manual version-only commit from the PyPI release process. The workflow now calculates the selected patch, minor, or major version before building and applies the same version to every `svv` and `svv-accelerated` artifact.

The existing upload choice is replaced with a functional `publish` Boolean. Build-only runs retain the current source version, while publishing runs upload the calculated version and update `svv/__init__.py` only after both PyPI projects have been published and verified.

## Changes

- Add `publish` and `version_bump` inputs to the manual PyPI workflow.
- Serialize production publication runs to prevent concurrent version selection.
- Calculate the source SHA and release version once and share them with every build job.
- Build base wheels, accelerated wheels, and the source distribution from the same source and version.
- Validate embedded package metadata and `svv.__version__` before uploading.
- Validate both PyPI credentials before the first upload begins.
- Confirm that the default branch has not advanced while artifacts are building.
- Verify that every expected artifact is present on PyPI, including artifacts skipped during a retry.
- Commit the published version to `svv/__init__.py` only after successful publication.
- Create the GitHub tag and release from the resulting version commit.
- Add a standalone release helper for version calculation, source updates, artifact inspection, and PyPI verification.

## Validation

- Confirmed patch, minor, and major calculations from `0.0.48` produce `0.0.49`, `0.1.0`, and `1.0.0`.
- Compiled the release helper with Python 3.9 and Python 3.10.
- Ran Ruff checks and formatting validation on the release helper.
- Validated the workflow with `actionlint` and a separate YAML parser.
- Confirmed the PyPI lookup logic against the existing `svv` and `svv-accelerated` `0.0.48` releases.

Closes #73
