### PR TITLE
Handle CRLF package version assignments

### DIFF
--- a/.github/scripts/release_version.py
+++ b/.github/scripts/release_version.py
@@ -22,7 +22,7 @@ VERSION_FILE_DEFAULT = Path("svv/__init__.py")
 SUPPORTED_PROJECTS = {"svv", "svv-accelerated"}
 VERSION_ASSIGNMENT = re.compile(
     r"^(?P<prefix>__version__\s*=\s*)(?P<quote>['\"])(?P<version>[^'\"]+)"
-    r"(?P=quote)(?P<trailing>[ \t]*)$",
+    r"(?P=quote)(?P<trailing>[ \t]*)(?:\r)?$",
     re.MULTILINE,
 )
 RELEASE_VERSION = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$")


### PR DESCRIPTION
## Summary

The PyPI workflow could not validate the Windows `svv` wheel because `svv/__init__.py` uses CRLF line endings inside that artifact. The version parser accepted LF endings only, so it reported that no `__version__` assignment was present and stopped the release before upload.

This change allows an optional carriage return at the end of a version-assignment line. LF behavior and the remainder of the release process are unchanged.

## Validation

- Validated the exact Windows `0.0.49` wheel from the failed workflow run.
- Confirmed version parsing with both LF and CRLF input.
- Compiled the helper with Python 3.9 and Python 3.10.
- Ran Ruff and `actionlint` successfully.
