### PR TITLE
Remove invalid release asset pattern

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -506,4 +506,3 @@ jobs:
             dist/svv-*.whl
             dist/svv-*.tar.gz
             dist/svv_accelerated-*.whl
-            dist/svv-accelerated-*.whl


### PR DESCRIPTION
## Summary

The PyPI publishing workflow successfully uploaded and verified the release artifacts, but GitHub release creation failed because `fail_on_unmatched_files` was enabled and the asset list included `dist/svv-accelerated-*.whl`. Wheel filenames normalize the accelerated package name to `svv_accelerated`, so the hyphenated pattern never matches an artifact.

This change removes the invalid hyphenated pattern while retaining the valid `dist/svv_accelerated-*.whl` pattern. Strict unmatched-file checking remains enabled so future missing release artifacts will still cause the workflow to fail.

## Validation

- Confirmed the remaining patterns match all 37 files published for version `0.0.49` across `svv` and `svv-accelerated`.
- Confirmed the workflow passes YAML parsing and `actionlint` validation.

## Release recovery

The packages for version `0.0.49` are already published to PyPI. Its missing GitHub release should be recovered separately without rerunning the complete publishing workflow.
