### PR TITLE
Prevent NumPy ABI failures and add NumExpr fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,14 @@ The package is published on PyPI as `svv`:
 pip install svv
 ```
 
+If you are installing into an existing environment and hit NumPy ABI errors such as
+`_ARRAY_API not found` or `numpy.core.multiarray failed to import`, reinstall in a
+clean environment with NumPy 1.x:
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install --force-reinstall "numpy<2" svv
+```
+
 On clusters / HPC systems (for example Stanford Sherlock), use a recent Python (3.9–3.12) and `pip`, and install into a 
 clean virtual environment or user site-packages. 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,21 @@ pip install svv
 ```
 
 If you are installing into an existing environment and hit NumPy ABI errors such as
-`_ARRAY_API not found` or `numpy.core.multiarray failed to import`, reinstall in a
-clean environment with NumPy 1.x:
+`_ARRAY_API not found` or `numpy.core.multiarray failed to import`, recreate the
+environment with a NumPy version supported by your Python version. For Python
+3.9–3.12, use NumPy 1.x:
 
 ```bash
 python -m pip install --upgrade pip
 python -m pip install --force-reinstall "numpy<2" svv
 ```
 
-On clusters / HPC systems (for example Stanford Sherlock), use a recent Python (3.9–3.12) and `pip`, and install into a 
-clean virtual environment or user site-packages. 
+Python 3.13 requires NumPy 2.1 or newer:
+
+```bash
+python -m pip install --upgrade pip
+python -m pip install --force-reinstall "numpy>=2.1" svv
+```
+
+On clusters / HPC systems (for example Stanford Sherlock), use a recent Python (3.9–3.13) and `pip`, and install into a
+clean virtual environment or user site-packages.

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.24; python_version < "3.12"
-numpy>=1.26; python_version >= "3.12"
+numpy>=1.24,<2; python_version < "3.12"
+numpy>=1.26,<2; python_version >= "3.12"
 scipy>=1.10.1; python_version < "3.12"
 scipy>=1.12.0; python_version >= "3.12"
 matplotlib>=3.7.5; python_version < "3.12"

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,6 @@
 numpy>=1.24,<2; python_version < "3.12"
-numpy>=1.26,<2; python_version >= "3.12"
+numpy>=1.26,<2; python_version >= "3.12" and python_version < "3.13"
+numpy>=2.1; python_version >= "3.13"
 scipy>=1.10.1; python_version < "3.12"
 scipy>=1.12.0; python_version >= "3.12"
 matplotlib>=3.7.5; python_version < "3.12"

--- a/docs/gui.html
+++ b/docs/gui.html
@@ -186,6 +186,11 @@
 python -m svv.visualize.gui --domain path/to/domain.dmn</code></pre>
       <p style="margin:0">If point-picking does not work, ensure the domain was created/solved/built before loading.</p>
     </div>
+
+    <div class="callout warning">
+      <strong>NumPy compatibility:</strong>
+      <p style="margin:.5rem 0 0">If importing the GUI fails with <code>_ARRAY_API not found</code> or <code>numpy.core.multiarray failed to import</code>, the environment likely mixed <code>numpy&gt;=2</code> with an older compiled dependency. Reinstall in a clean environment with <code>python -m pip install --force-reinstall "numpy&lt;2" svv</code>.</p>
+    </div>
   </main>
 
   <footer>

--- a/docs/gui.html
+++ b/docs/gui.html
@@ -189,7 +189,7 @@ python -m svv.visualize.gui --domain path/to/domain.dmn</code></pre>
 
     <div class="callout warning">
       <strong>NumPy compatibility:</strong>
-      <p style="margin:.5rem 0 0">If importing the GUI fails with <code>_ARRAY_API not found</code> or <code>numpy.core.multiarray failed to import</code>, the environment likely mixed <code>numpy&gt;=2</code> with an older compiled dependency. Reinstall in a clean environment with <code>python -m pip install --force-reinstall "numpy&lt;2" svv</code>.</p>
+      <p style="margin:.5rem 0 0">If importing the GUI fails with <code>_ARRAY_API not found</code> or <code>numpy.core.multiarray failed to import</code>, recreate the environment with a NumPy version supported by your Python version. On Python 3.9–3.12, use <code>python -m pip install --force-reinstall "numpy&lt;2" svv</code>. Python 3.13 requires NumPy 2.1 or newer; use <code>python -m pip install --force-reinstall "numpy&gt;=2.1" svv</code>.</p>
     </div>
   </main>
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -47,6 +47,7 @@
       <pre data-copy><code class="language-shell">python -m pip install --upgrade pip  # upgrade installer
 python -m pip install svv</code></pre>
       <p>This installs the <em>core</em> pre-built synthetic vascular-generation wheel from PyPI.</p>
+      <div class="callout warning"><strong>Troubleshooting:</strong> If you see NumPy ABI errors such as <code>_ARRAY_API not found</code> or <code>numpy.core.multiarray failed to import</code>, recreate the environment and reinstall with <code>python -m pip install --force-reinstall "numpy&lt;2" svv</code>.</div>
       <div class="callout"><strong>Need hemodynamics solvers?</strong> They are not included by default—see <a href="#simulation">Simulation extras</a>.</div>
     </section>
 
@@ -59,7 +60,7 @@ python -m pip install svv</code></pre>
     <li><strong>Memory:</strong> 2 GB RAM minimum (8 GB recommended for large vascular trees).</li>
         <li><strong>C++17 tool-chain:</strong> required <em>only</em> for source builds (see call-out below).</li>
         <li><strong>Build-time Python deps:</strong> <code>cython&nbsp;&ge;0.29&nbsp;&lt;3.0</code>,
-        <code>wheel</code>, <code>numpy&nbsp;&ge;1.22</code> (pulled in automatically by
+        <code>wheel</code>, <code>numpy&nbsp;&ge;1.24&nbsp;&lt;2</code> (pulled in automatically by
         <code>pip</code>).</li>
       </ul>
       <!-- platform-specific tool-chain tips -->

--- a/docs/install.html
+++ b/docs/install.html
@@ -47,7 +47,7 @@
       <pre data-copy><code class="language-shell">python -m pip install --upgrade pip  # upgrade installer
 python -m pip install svv</code></pre>
       <p>This installs the <em>core</em> pre-built synthetic vascular-generation wheel from PyPI.</p>
-      <div class="callout warning"><strong>Troubleshooting:</strong> If you see NumPy ABI errors such as <code>_ARRAY_API not found</code> or <code>numpy.core.multiarray failed to import</code>, recreate the environment and reinstall with <code>python -m pip install --force-reinstall "numpy&lt;2" svv</code>.</div>
+      <div class="callout warning"><strong>Troubleshooting:</strong> If you see NumPy ABI errors such as <code>_ARRAY_API not found</code> or <code>numpy.core.multiarray failed to import</code>, recreate the environment with a NumPy version supported by your Python version. On Python 3.9–3.12, use <code>python -m pip install --force-reinstall "numpy&lt;2" svv</code>. Python 3.13 requires NumPy 2.1 or newer; use <code>python -m pip install --force-reinstall "numpy&gt;=2.1" svv</code>.</div>
       <div class="callout"><strong>Need hemodynamics solvers?</strong> They are not included by default—see <a href="#simulation">Simulation extras</a>.</div>
     </section>
 
@@ -60,7 +60,8 @@ python -m pip install svv</code></pre>
     <li><strong>Memory:</strong> 2 GB RAM minimum (8 GB recommended for large vascular trees).</li>
         <li><strong>C++17 tool-chain:</strong> required <em>only</em> for source builds (see call-out below).</li>
         <li><strong>Build-time Python deps:</strong> <code>cython&nbsp;&ge;0.29&nbsp;&lt;3.0</code>,
-        <code>wheel</code>, <code>numpy&nbsp;&ge;1.24&nbsp;&lt;2</code> (pulled in automatically by
+        <code>wheel</code>, <code>numpy&nbsp;&ge;1.24&nbsp;&lt;2</code> on Python 3.9–3.12 or
+        <code>numpy&nbsp;&ge;2.1</code> on Python 3.13 (pulled in automatically by
         <code>pip</code>).</li>
       </ul>
       <!-- platform-specific tool-chain tips -->

--- a/environment-gui-linux.yml
+++ b/environment-gui-linux.yml
@@ -7,7 +7,7 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.9,<3.12
-  - numpy
+  - numpy<2
   - psutil
   - pyside6>=6.4
   - pyvista>=0.41

--- a/environment-gui.yml
+++ b/environment-gui.yml
@@ -8,7 +8,7 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.9,<3.13
-  - numpy
+  - numpy<2
   - psutil
   - pyside6>=6.4
   - pyvista>=0.41

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ requires = [
   "wheel>=0.36",
   # Ensure PEP 517 build environments have the headers/tools needed to compile extensions
   "Cython>=3.0.7",
-  "numpy>=1.24; python_version < '3.12'",
-  "numpy>=1.26; python_version >= '3.12'",
+  "numpy>=1.24,<2; python_version < '3.12'",
+  "numpy>=1.26,<2; python_version >= '3.12'",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@ requires = [
   # Ensure PEP 517 build environments have the headers/tools needed to compile extensions
   "Cython>=3.0.7",
   "numpy>=1.24,<2; python_version < '3.12'",
-  "numpy>=1.26,<2; python_version >= '3.12'",
+  "numpy>=1.26,<2; python_version >= '3.12' and python_version < '3.13'",
+  "numpy>=2.1; python_version >= '3.13'",
 ]
 
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.24,<2; python_version < "3.10"
-numpy>=1.24; python_version >= "3.10" and python_version < "3.12"
-numpy>=1.26; python_version >= "3.12"
+numpy>=1.24,<2; python_version >= "3.10" and python_version < "3.12"
+numpy>=1.26,<2; python_version >= "3.12"
 scipy>=1.10.1; python_version < "3.12"
 scipy>=1.12.0; python_version >= "3.12"
 matplotlib>=3.7.5; python_version < "3.12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy>=1.24,<2; python_version < "3.10"
 numpy>=1.24,<2; python_version >= "3.10" and python_version < "3.12"
-numpy>=1.26,<2; python_version >= "3.12"
+numpy>=1.26,<2; python_version >= "3.12" and python_version < "3.13"
+numpy>=2.1; python_version >= "3.13"
 scipy>=1.10.1; python_version < "3.12"
 scipy>=1.12.0; python_version >= "3.12"
 matplotlib>=3.7.5; python_version < "3.12"

--- a/svv/tree/branch/bifurcation.py
+++ b/svv/tree/branch/bifurcation.py
@@ -21,9 +21,17 @@ from svv.tree.utils.c_obb import obb_any
 from svv.tree.utils.c_angle import get_angles
 from svv.tree.utils.c_extend import update_alt
 from scipy.sparse import coo_matrix, lil_matrix
-import numexpr as ne
 import matplotlib.pyplot as plt
-ne.set_num_threads(min(16, max(1, os.cpu_count() or 1)))
+
+_NUMEXPR = None
+if int(str(np.__version__).split(".", 1)[0]) < 2:
+    try:
+        import numexpr as _NUMEXPR
+    except Exception:
+        _NUMEXPR = None
+
+if _NUMEXPR is not None:
+    _NUMEXPR.set_num_threads(min(16, max(1, os.cpu_count() or 1)))
 
 #[TODO] angle constraint to make sure that daughters are wide enough apart
 #[TODO] remove terminal and parent sister collision constraint
@@ -1939,10 +1947,15 @@ def scale_column_with_multiply(array, col_index, scalar, out_index):
 """
 
 def ne_multiply(column, scalar, out):
-    ne.evaluate('column * scalar', out=out)
+    if _NUMEXPR is None:
+        np.multiply(column, scalar, out=out)
+        return
+    _NUMEXPR.evaluate('column * scalar', out=out)
 
 def ne_scale(radius, length, radius_exp, length_exp):
-    scale = np.pi * ne.evaluate('sum(radius ** radius_exp * length ** length_exp)')
+    if _NUMEXPR is None:
+        return np.pi * np.sum(radius ** radius_exp * length ** length_exp)
+    scale = np.pi * _NUMEXPR.evaluate('sum(radius ** radius_exp * length ** length_exp)')
     return scale
 
 def get_points(tree, n_points, **kwargs):

--- a/svv/visualize/gui/requirements-gui.txt
+++ b/svv/visualize/gui/requirements-gui.txt
@@ -12,7 +12,7 @@ pyvistaqt>=0.11.0
 vtk
 
 # Numeric stack used heavily by the GUI
-numpy>=1.24
+numpy>=1.24,<2
 
 # Optional: system monitoring in status bar
 psutil>=5.9.0

--- a/svv/visualize/gui/requirements-gui.txt
+++ b/svv/visualize/gui/requirements-gui.txt
@@ -12,7 +12,9 @@ pyvistaqt>=0.11.0
 vtk
 
 # Numeric stack used heavily by the GUI
-numpy>=1.24,<2
+numpy>=1.24,<2; python_version < "3.12"
+numpy>=1.26,<2; python_version >= "3.12" and python_version < "3.13"
+numpy>=2.1; python_version >= "3.13"
 
 # Optional: system monitoring in status bar
 psutil>=5.9.0

--- a/test/test_numexpr_fallback.py
+++ b/test/test_numexpr_fallback.py
@@ -1,0 +1,18 @@
+import numpy as np
+
+from svv.tree.branch import bifurcation as bifurcation_mod
+
+
+def test_numexpr_helpers_fall_back_to_numpy(monkeypatch):
+    monkeypatch.setattr(bifurcation_mod, "_NUMEXPR", None)
+
+    column = np.array([1.0, 2.0, 3.0], dtype=float)
+    out = np.zeros_like(column)
+    bifurcation_mod.ne_multiply(column, 2.5, out)
+    np.testing.assert_allclose(out, column * 2.5)
+
+    radius = np.array([1.0, 2.0], dtype=float)
+    length = np.array([3.0, 4.0], dtype=float)
+    scale = bifurcation_mod.ne_scale(radius, length, 2.0, 1.0)
+    expected = np.pi * np.sum(radius ** 2.0 * length)
+    np.testing.assert_allclose(scale, expected)


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->
<!-- Suggested title: Prevent NumPy ABI failures and add NumExpr fallback -->

## Current situation

Closes #79.

Supported installations can resolve NumPy 2 alongside binary dependencies built for NumPy 1, resulting in import failures before tree generation begins. The bifurcation module also imports NumExpr eagerly even though its two uses have direct NumPy equivalents. Because Python 3.13 requires NumPy 2, a single NumPy 1.x constraint cannot cover every supported Python version.

## Release Notes

- Constrain Python 3.9–3.12 environments to NumPy 1.x and require NumPy 2.1 or newer on Python 3.13.
- Fall back to NumPy operations when NumExpr is unavailable or incompatible.
- Add version-specific troubleshooting guidance for NumPy ABI errors.

## Documentation

Updated the README and installation and GUI documentation with the supported NumPy ranges and recovery commands for Python 3.9–3.12 and Python 3.13.

## Testing

- [x] `python -m pytest test/test_numexpr_fallback.py -q` (`1 passed`)
- [x] Validated that exactly one NumPy requirement applies for each Python version from 3.9 through 3.13 across runtime, build, Binder, and GUI requirements.
- [x] Confirmed that Python 3.12 resolves NumPy 1.26.4 and Python 3.13 resolves NumPy 2.5.2 using binary-only dry runs.
- [ ] GitHub Actions operating-system and Python-version matrix.

## Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
