### PR TITLE
Use waveform inflow for unsteady 0D exports with custom flow

### DIFF
--- a/svv/simulation/fluid/rom/zero_d/zerod_forest.py
+++ b/svv/simulation/fluid/rom/zero_d/zerod_forest.py
@@ -203,17 +203,17 @@ def export_0d_simulation(forest, network_id, inlets, steady=True, outdir=None, f
                         bc_values["Q"] = [q_in, q_in]
                         bc_values["t"] = [0, 1]
                     else:
-                        if isinstance(flow, type(None)):
-                            time, flow_wave = generate_physiologic_wave(
-                                networks[tree_id].data[vessel_id, 22],
-                                networks[tree_id].data[vessel_id, 21] * 2,
-                            )
-                            bc_values["Q"] = np.asarray(flow_wave, dtype=float).tolist()
-                            bc_values["t"] = np.asarray(time, dtype=float).tolist()
-                        else:
-                            q_in = float(flow)
-                            bc_values["Q"] = [q_in, q_in]
-                            bc_values["t"] = [0, 1]
+                        q_in = (
+                            float(networks[tree_id].data[vessel_id, 22])
+                            if isinstance(flow, type(None))
+                            else float(flow)
+                        )
+                        time, flow_wave = generate_physiologic_wave(
+                            q_in,
+                            networks[tree_id].data[vessel_id, 21] * 2,
+                        )
+                        bc_values["Q"] = np.asarray(flow_wave, dtype=float).tolist()
+                        bc_values["t"] = np.asarray(time, dtype=float).tolist()
                         if bc_values["Q"]:
                             bc_values["Q"][-1] = bc_values["Q"][0]
                         simulation_parameters["number_of_time_pts_per_cardiac_cycle"] = len(bc_values["Q"])

--- a/svv/simulation/fluid/rom/zero_d/zerod_tree.py
+++ b/svv/simulation/fluid/rom/zero_d/zerod_tree.py
@@ -184,14 +184,10 @@ def export_0d_simulation(tree ,steady=True ,outdir=None ,folder="0d_tmp" ,number
                 bc_values["Q"] = [q_in, q_in]
                 bc_values["t"] = [0, 1]
             else:
-                if isinstance(flow, type(None)):
-                    time, flow_wave = generate_physiologic_wave(tree.data[vessel, 22], tree.data[vessel, 21] * 2)
-                    bc_values["Q"] = np.asarray(flow_wave, dtype=float).tolist()
-                    bc_values["t"] = np.asarray(time, dtype=float).tolist()
-                else:
-                    q_in = float(flow)
-                    bc_values["Q"] = [q_in, q_in]
-                    bc_values["t"] = [0, 1]
+                q_in = float(tree.data[vessel, 22]) if isinstance(flow, type(None)) else float(flow)
+                time, flow_wave = generate_physiologic_wave(q_in, tree.data[vessel, 21] * 2)
+                bc_values["Q"] = np.asarray(flow_wave, dtype=float).tolist()
+                bc_values["t"] = np.asarray(time, dtype=float).tolist()
                 if bc_values["Q"]:
                     bc_values["Q"][-1] = bc_values["Q"][0]
                 simulation_parameters["number_of_time_pts_per_cardiac_cycle"] = len(bc_values["Q"])

--- a/test/test_zerod_export_solver_opt_in.py
+++ b/test/test_zerod_export_solver_opt_in.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 
 import numpy as np
@@ -19,6 +20,11 @@ def _base_tree_data() -> np.ndarray:
 
 def _raise_if_called():
     raise AssertionError("get_solver_0d_exe() should not be called")
+
+
+def _load_inflow_bc(case_dir):
+    data = json.loads((case_dir / "solver_0d.in").read_text(encoding="utf-8"))
+    return next(bc for bc in data["boundary_conditions"] if bc["bc_name"] == "INFLOW")
 
 
 def test_tree_0d_export_does_not_probe_solver_when_not_requested(monkeypatch, tmp_path):
@@ -99,3 +105,78 @@ def test_forest_0d_export_does_not_probe_solver_when_not_requested(monkeypatch, 
     run_text = (outdir / "run.py").read_text(encoding="utf-8")
     assert "CHILD_PID_FILE" in run_text
     assert "OUTPUT_FILENAME" in run_text
+
+
+def test_tree_0d_export_uses_waveform_for_unsteady_custom_flow(monkeypatch, tmp_path):
+    tree = SimpleNamespace(
+        data=_base_tree_data(),
+        parameters=SimpleNamespace(terminal_pressure=100.0, kinematic_viscosity=0.04),
+    )
+    calls = []
+
+    def _fake_waveform(flow_value, diameter, *args, **kwargs):
+        calls.append((flow_value, diameter))
+        return np.array([0.0, 0.5, 1.0]), np.array([2.0, 3.0, 4.0])
+
+    monkeypatch.setattr(zerod_tree, "generate_physiologic_wave", _fake_waveform)
+
+    zerod_tree.export_0d_simulation(
+        tree,
+        outdir=str(tmp_path),
+        folder="case",
+        steady=False,
+        flow=2.5,
+    )
+
+    inflow = _load_inflow_bc(tmp_path / "case")
+
+    assert calls == [(2.5, 0.2)]
+    assert inflow["bc_values"]["t"] == [0.0, 0.5, 1.0]
+    assert inflow["bc_values"]["Q"] == [2.0, 3.0, 2.0]
+    assert (tmp_path / "case" / "inflow.flow").read_text(encoding="utf-8").splitlines() == [
+        "0.0  2.0",
+        "0.5  3.0",
+        "1.0  2.0",
+    ]
+
+
+def test_forest_0d_export_uses_waveform_for_unsteady_custom_flow(monkeypatch, tmp_path):
+    tree = SimpleNamespace(
+        data=_base_tree_data(),
+        parameters=SimpleNamespace(kinematic_viscosity=0.04, fluid_density=1.06),
+    )
+    connection = SimpleNamespace(connected_network=[tree], vessels=[[]])
+    forest = SimpleNamespace(
+        n_trees_per_network=[1],
+        networks=[[tree]],
+        connections=SimpleNamespace(tree_connections=[connection]),
+    )
+    calls = []
+
+    def _fake_waveform(flow_value, diameter, *args, **kwargs):
+        calls.append((flow_value, diameter))
+        return np.array([0.0, 0.25, 0.5]), np.array([5.0, 6.0, 7.0])
+
+    monkeypatch.setattr(zerod_forest, "generate_physiologic_wave", _fake_waveform)
+
+    zerod_forest.export_0d_simulation(
+        forest,
+        network_id=0,
+        inlets=[0],
+        outdir=str(tmp_path),
+        folder="case",
+        steady=False,
+        flow=3.5,
+        get_0d_solver=False,
+    )
+
+    inflow = _load_inflow_bc(tmp_path / "case")
+
+    assert calls == [(3.5, 0.2)]
+    assert inflow["bc_values"]["t"] == [0.0, 0.25, 0.5]
+    assert inflow["bc_values"]["Q"] == [5.0, 6.0, 5.0]
+    assert (tmp_path / "case" / "inflow.flow").read_text(encoding="utf-8").splitlines() == [
+        "0.0  5.0",
+        "0.25  6.0",
+        "0.5  5.0",
+    ]


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation

Closes #81.

When a tree or forest 0D export uses `steady=False` with a custom `flow`, the exporter currently writes a constant two-point inlet instead of a physiologic waveform. This makes the requested unsteady boundary condition steady.

## Release Notes

- Use a supplied custom flow to generate the physiologic waveform for unsteady tree and forest 0D exports.
- Close the waveform period by matching the final flow sample to the first sample.
- Keep the solver time-point count synchronized with the generated waveform.
- Add regression coverage for tree and forest exports.

## Documentation

No documentation changes are required. The public API is unchanged, and the corrected custom-flow behavior is covered by regression tests.

## Testing

- [x] `python -m pytest test/test_zerod_export_solver_opt_in.py -q` — 5 passed.
- [x] `python -m pytest test/test_solver_0d_selector.py test/test_zerod_export_solver_opt_in.py test/test_zerod_run_script_paths.py -q` — 11 passed.
- [ ] GitHub Actions operating-system and Python-version matrix.
- The local GUI pipeline test could not be collected because `pymeshfix` is not installed in the local environment; the configured workflow will exercise the repository dependency set.

## Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).