### PR TITLE
Correct PVD time controls and scalar handling in the Solution Inspector

### DIFF
--- a/svv/visualize/gui/solution_inspector.py
+++ b/svv/visualize/gui/solution_inspector.py
@@ -5514,8 +5514,7 @@ class SolutionInspectorWidget(QWidget):
 
                 for time_idx, time_val in enumerate(self._time_values):
                     # Load mesh at this time step
-                    if hasattr(self._reader, "set_active_time_index"):
-                        self._reader.set_active_time_index(time_idx)
+                    self._set_reader_time_index(time_idx)
 
                     try:
                         mesh = self._reader.read()
@@ -5556,8 +5555,7 @@ class SolutionInspectorWidget(QWidget):
                 QApplication.processEvents()
 
             # Restore original time step
-            if hasattr(self._reader, "set_active_time_index"):
-                self._reader.set_active_time_index(original_time_idx)
+            self._set_reader_time_index(original_time_idx)
             self._update_mesh_from_reader(original_time_idx)
 
         except Exception as e:
@@ -6534,8 +6532,7 @@ class SolutionInspectorWidget(QWidget):
 
         # Load mesh for this time index
         try:
-            if hasattr(self._reader, "set_active_time_index"):
-                self._reader.set_active_time_index(int(time_index))
+            self._set_reader_time_index(int(time_index))
             mesh = self._reader.read()
         except Exception:
             return
@@ -6925,7 +6922,6 @@ class SolutionInspectorWidget(QWidget):
         self._current_scalar_name = None
         self._scalar_label_auto_text = ""
         self.scalar_label_edit.clear()
-
         if self._time_values:
             self.time_slider.setEnabled(True)
             self.time_slider.setRange(0, len(self._time_values) - 1)
@@ -6958,6 +6954,37 @@ class SolutionInspectorWidget(QWidget):
         except Exception:
             self.time_label.setText(f"Time: {t}")
 
+    def _set_reader_time_index(self, index: int) -> bool:
+        """Select a reader time step across differing PyVista reader APIs."""
+        if self._reader is None:
+            return False
+
+        idx = int(index)
+
+        if hasattr(self._reader, "set_active_time_index"):
+            try:
+                self._reader.set_active_time_index(idx)
+                return True
+            except Exception:
+                pass
+
+        if hasattr(self._reader, "set_active_time_point"):
+            try:
+                self._reader.set_active_time_point(idx)
+                return True
+            except Exception:
+                pass
+
+        if hasattr(self._reader, "set_active_time_value") and self._time_values:
+            try:
+                if 0 <= idx < len(self._time_values):
+                    self._reader.set_active_time_value(self._time_values[idx])
+                    return True
+            except Exception:
+                pass
+
+        return False
+
     def _on_time_index_changed(self, index: int) -> None:
         if self._reader is None:
             return
@@ -6970,8 +6997,8 @@ class SolutionInspectorWidget(QWidget):
             return
 
         try:
-            if time_index is not None and hasattr(self._reader, "set_active_time_index"):
-                self._reader.set_active_time_index(int(time_index))
+            if time_index is not None:
+                self._set_reader_time_index(int(time_index))
             mesh = self._reader.read()
         except Exception:
             return
@@ -7145,8 +7172,7 @@ class SolutionInspectorWidget(QWidget):
 
         for idx in range(len(self._time_values)):
             try:
-                if hasattr(self._reader, "set_active_time_index"):
-                    self._reader.set_active_time_index(idx)
+                self._set_reader_time_index(idx)
                 mesh = self._reader.read()
             except Exception:
                 continue
@@ -7185,8 +7211,7 @@ class SolutionInspectorWidget(QWidget):
 
         # Restore original time index
         try:
-            if hasattr(self._reader, "set_active_time_index"):
-                self._reader.set_active_time_index(original_index)
+            self._set_reader_time_index(original_index)
         except Exception:
             pass
 

--- a/svv/visualize/gui/solution_inspector.py
+++ b/svv/visualize/gui/solution_inspector.py
@@ -6922,6 +6922,13 @@ class SolutionInspectorWidget(QWidget):
         self._current_scalar_name = None
         self._scalar_label_auto_text = ""
         self.scalar_label_edit.clear()
+        has_time_series = len(self._time_values) > 1
+
+        if getattr(self, "auto_range_cb", None) and self.auto_range_cb.isChecked():
+            self.global_range_cb.blockSignals(True)
+            self.global_range_cb.setChecked(has_time_series)
+            self.global_range_cb.blockSignals(False)
+
         if self._time_values:
             self.time_slider.setEnabled(True)
             self.time_slider.setRange(0, len(self._time_values) - 1)

--- a/svv/visualize/gui/solution_inspector.py
+++ b/svv/visualize/gui/solution_inspector.py
@@ -2133,7 +2133,7 @@ class TimeSeriesPlotDialog(QDialog):
         layout.addLayout(tools_layout)
 
         # Store plot data for refreshing
-        self._plot_data = []  # List of (times, values, label) tuples
+        self._plot_data = []  # List of (times, values, label[, color]) tuples
         self._lines = []  # matplotlib line objects
         self._xlabel = "Time"
         self._ylabel = "Value"
@@ -2707,8 +2707,11 @@ class TimeSeriesPlotDialog(QDialog):
         # Clear previous derivative
         self._clear_derivative()
 
-        # Use first data series
-        times, values, label = self._plot_data[0]
+        # Use first data series; support legacy 3-tuples and current 4-tuples.
+        data_tuple = self._plot_data[0]
+        times = data_tuple[0]
+        values = data_tuple[1]
+        label = data_tuple[2]
         times = np.asarray(times)
         values = np.asarray(values)
 

--- a/svv/visualize/gui/solution_inspector.py
+++ b/svv/visualize/gui/solution_inspector.py
@@ -7241,7 +7241,7 @@ class SolutionInspectorWidget(QWidget):
         if rng is None:
             return
         vmin, vmax = rng
-        if not self.auto_range_cb.isChecked():
+        if self.auto_range_cb.isChecked():
             self.scalar_min_spin.blockSignals(True)
             self.scalar_max_spin.blockSignals(True)
             self.scalar_min_spin.setValue(vmin)

--- a/test/test_zerod_gui_pipeline.py
+++ b/test/test_zerod_gui_pipeline.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 
 pytest.importorskip("PySide6")
 
@@ -316,4 +317,43 @@ def test_solution_inspector_manual_scalar_range_persists_across_time_changes(mon
     assert inspector.scalar_min_spin.value() == 1.2
     assert inspector.scalar_max_spin.value() == 9.8
 
+    _close_gui(app, gui)
+
+
+def test_time_series_dialog_derivative_accepts_colored_plot_tuples(monkeypatch):
+    app, gui = _make_gui(monkeypatch)
+    module = sys.modules[type(gui.solution_inspector).__module__]
+    dialog = module.TimeSeriesPlotDialog(gui)
+
+    class _FakeLine:
+        pass
+
+    class _FakeAxes:
+        def plot(self, *_args, **_kwargs):
+            return [_FakeLine()]
+
+        def legend(self, *_args, **_kwargs):
+            return None
+
+    class _FakeFigure:
+        def tight_layout(self):
+            return None
+
+    class _FakeCanvas:
+        def draw(self):
+            return None
+
+    monkeypatch.setattr(dialog, "_clear_derivative", lambda: None)
+    dialog._mpl_available = True
+    dialog._ax = _FakeAxes()
+    dialog._fig = _FakeFigure()
+    dialog._canvas = _FakeCanvas()
+    dialog.deriv_separate_cb.setChecked(False)
+    dialog._plot_data = [([0.0, 1.0, 2.0], [1.0, 3.0, 5.0], "Series A", "blue")]
+
+    dialog._compute_derivative()
+
+    assert dialog._derivative_line is not None
+
+    dialog.close()
     _close_gui(app, gui)

--- a/test/test_zerod_gui_pipeline.py
+++ b/test/test_zerod_gui_pipeline.py
@@ -192,3 +192,47 @@ def test_solution_inspector_plotter_ready_replays_pending_camera_reset(monkeypat
     assert inspector._pending_camera_reset is False
 
     _close_gui(app, gui)
+
+
+def test_solution_inspector_time_change_uses_pvd_time_point_api(monkeypatch):
+    app, gui = _make_gui(monkeypatch)
+    inspector = gui.solution_inspector
+
+    class _FakeMesh:
+        def __init__(self, idx):
+            self.idx = idx
+
+    class _FakeReader:
+        def __init__(self):
+            self.active_idx = 0
+            self.time_values = [0.0, 0.1, 0.2]
+            self.calls = []
+
+        def set_active_time_point(self, idx):
+            self.calls.append(idx)
+            self.active_idx = idx
+
+        def read(self):
+            return _FakeMesh(self.active_idx)
+
+    class _FakePV:
+        class MultiBlock:
+            pass
+
+    renders = []
+    monkeypatch.setattr(inspector, "_update_scalar_range", lambda: None)
+    monkeypatch.setattr(inspector, "_render_current_mesh", lambda *, reset_camera=False: renders.append((inspector._current_mesh.idx, reset_camera)))
+    monkeypatch.setattr(inspector, "_update_calculator_mesh", lambda: None)
+
+    inspector._pv = _FakePV()
+    inspector._reader = _FakeReader()
+    inspector._time_values = [0.0, 0.1, 0.2]
+
+    inspector._on_time_index_changed(2)
+
+    assert inspector._reader.calls == [2]
+    assert inspector._current_time_index == 2
+    assert inspector._current_mesh.idx == 2
+    assert renders == [(2, False)]
+
+    _close_gui(app, gui)

--- a/test/test_zerod_gui_pipeline.py
+++ b/test/test_zerod_gui_pipeline.py
@@ -276,3 +276,44 @@ def test_solution_inspector_load_solution_enables_global_range_for_time_series(m
     assert inspector.global_range_cb.isChecked() is True
 
     _close_gui(app, gui)
+
+
+def test_solution_inspector_manual_scalar_range_persists_across_time_changes(monkeypatch):
+    app, gui = _make_gui(monkeypatch)
+    inspector = gui.solution_inspector
+
+    class _FakeReader:
+        def __init__(self):
+            self.active_idx = 0
+
+        def set_active_time_point(self, idx):
+            self.active_idx = idx
+
+        def read(self):
+            return object()
+
+    class _FakePV:
+        class MultiBlock:
+            pass
+
+    monkeypatch.setattr(inspector, "_compute_local_range", lambda _name: (0.0, 100.0))
+    monkeypatch.setattr(inspector, "_render_current_mesh", lambda *, reset_camera=False: None)
+    monkeypatch.setattr(inspector, "_update_calculator_mesh", lambda: None)
+
+    inspector._pv = _FakePV()
+    inspector._reader = _FakeReader()
+    inspector._time_values = [0.0, 0.1, 0.2]
+    inspector._current_scalar_name = "Pressure [mmHg]"
+    inspector._current_mesh = object()
+    inspector.global_range_cb.setChecked(False)
+    inspector.auto_range_cb.setChecked(False)
+    inspector.scalar_min_spin.setValue(1.2)
+    inspector.scalar_max_spin.setValue(9.8)
+
+    inspector._on_time_index_changed(2)
+
+    assert inspector._current_time_index == 2
+    assert inspector.scalar_min_spin.value() == 1.2
+    assert inspector.scalar_max_spin.value() == 9.8
+
+    _close_gui(app, gui)

--- a/test/test_zerod_gui_pipeline.py
+++ b/test/test_zerod_gui_pipeline.py
@@ -236,3 +236,43 @@ def test_solution_inspector_time_change_uses_pvd_time_point_api(monkeypatch):
     assert renders == [(2, False)]
 
     _close_gui(app, gui)
+
+
+def test_solution_inspector_load_solution_enables_global_range_for_time_series(monkeypatch, tmp_path):
+    app, gui = _make_gui(monkeypatch)
+    inspector = gui.solution_inspector
+
+    class _FakeReader:
+        def __init__(self):
+            self.time_values = [0.0, 0.1, 0.2]
+
+        def set_active_time_point(self, _idx):
+            pass
+
+        def read(self):
+            return object()
+
+    class _FakePV:
+        class MultiBlock:
+            pass
+
+        @staticmethod
+        def get_reader(_path):
+            return _FakeReader()
+
+    solution_path = tmp_path / "timeseries.pvd"
+    solution_path.write_text("<VTKFile/>", encoding="utf-8")
+
+    monkeypatch.setattr(inspector, "_update_mesh_from_reader", lambda *args, **kwargs: None)
+    monkeypatch.setattr(inspector, "_populate_scalar_fields", lambda: None)
+    monkeypatch.setattr(inspector, "_populate_vector_fields", lambda: None)
+    monkeypatch.setattr(inspector, "_update_statistics", lambda: None)
+
+    inspector._pv = _FakePV()
+    inspector.auto_range_cb.setChecked(True)
+    inspector.global_range_cb.setChecked(False)
+
+    assert inspector._load_solution(str(solution_path)) is True
+    assert inspector.global_range_cb.isChecked() is True
+
+    _close_gui(app, gui)


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation

Closes #82.

Time-dependent PVD results can expose different PyVista time-selection APIs, causing some readers not to advance during playback. Automatic scalar limits can also vary between time steps, manual limits can be overwritten, and derivative plotting fails when a plot-series record includes color metadata.

## Release Notes

- Support reader APIs for active time indices, time points, and time values.
- Enable a stable global scalar range by default for automatically ranged time-series results.
- Preserve manually selected scalar limits during playback.
- Accept both legacy three-field and colored four-field plot-series records when computing derivatives.
- Add regression coverage for each corrected behavior.

## Documentation

No user-facing documentation changes are required. The public interface is unchanged, and the corrected Solution Inspector behavior is covered by regression tests.

## Testing

- [x] Complete `test/test_zerod_gui_pipeline.py` module — 12 passed.
- [x] Local execution used import-only stubs for unavailable `pymeshfix` and `trimesh`; the tested Solution Inspector paths do not invoke either package.
- [x] `git diff --check upstream/main...HEAD`.
- [ ] GitHub Actions operating-system and Python-version matrix.

## Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).