### PR TITLE
Preserve vascular spline points during tissue tetrahedralization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ import re
 import inspect
 from pathlib import Path
 import multiprocessing
+from textwrap import dedent
 
 num_cores = multiprocessing.cpu_count() // 2
 
@@ -386,6 +387,213 @@ def _copy_windows_runtime_dlls(executable_path, destination_dir):
     return copied
 
 
+def _tetgen_os_dir() -> str:
+    sysname = platform.system()
+    if sysname == "Linux":
+        return "Linux"
+    if sysname == "Windows":
+        return "Windows"
+    if sysname == "Darwin":
+        return "Mac"
+    raise RuntimeError(f"Unsupported OS for TetGen CLI packaging: {sysname}")
+
+
+def _tetgen_arch_dir(os_dir: str) -> str:
+    override = os.environ.get("SVV_TETGEN_ARCH", "").strip()
+    if override:
+        ov = override.lower()
+        if ov in {"x86_64", "amd64"}:
+            return "x86_64"
+        if ov in {"aarch64", "arm64"}:
+            return "aarch64"
+        if ov == "universal2":
+            return "universal2"
+        return override
+
+    if os_dir == "Mac":
+        repo_root = Path(__file__).resolve().parent
+        exe_name = _tetgen_expected_filenames(os_dir, "universal2")[0]
+        uni_dir = repo_root / "svv" / "utils" / "meshing" / "Mac" / "universal2"
+        if (uni_dir / exe_name).is_file():
+            return "universal2"
+
+    machine = platform.machine().strip().lower()
+    if machine in {"x86_64", "amd64"}:
+        return "x86_64"
+    if machine in {"aarch64", "arm64"}:
+        return "aarch64"
+    return machine or "unknown"
+
+
+def _tetgen_expected_filenames(os_dir: str, arch_dir: str) -> list:
+    del arch_dir
+    name = "tetgen"
+    if os_dir == "Windows":
+        name += ".exe"
+    return [name]
+
+
+def _find_tetgen_cli_source_dir(source_extract_root: str) -> str:
+    root = Path(source_extract_root).resolve()
+    candidates = [root]
+    if root.is_dir():
+        candidates.extend(sorted(path for path in root.iterdir() if path.is_dir()))
+
+    for candidate in candidates:
+        src_dir = candidate / "src"
+        if (src_dir / "tetgen.cxx").is_file() and (src_dir / "predicates.cxx").is_file():
+            return str(candidate)
+
+    for tetgen_src in root.rglob("tetgen.cxx"):
+        src_dir = tetgen_src.parent
+        if src_dir.name == "src" and (src_dir / "predicates.cxx").is_file():
+            return str(src_dir.parent)
+
+    raise RuntimeError(
+        f"Could not locate TetGen CLI sources under {root}. Expected src/tetgen.cxx and src/predicates.cxx."
+    )
+
+
+def _write_tetgen_cli_cmakelists(cmake_path: str) -> None:
+    Path(cmake_path).write_text(
+        dedent(
+            """
+            cmake_minimum_required(VERSION 3.16)
+            project(svv_tetgen_cli LANGUAGES CXX)
+
+            if(NOT DEFINED TETGEN_SOURCE_DIR)
+              message(FATAL_ERROR "TETGEN_SOURCE_DIR must be set")
+            endif()
+
+            set(CMAKE_CXX_STANDARD 11)
+            set(CMAKE_CXX_STANDARD_REQUIRED ON)
+            set(CMAKE_CXX_EXTENSIONS OFF)
+
+            add_executable(tetgen
+              "${TETGEN_SOURCE_DIR}/src/tetgen.cxx"
+              "${TETGEN_SOURCE_DIR}/src/predicates.cxx"
+            )
+            target_include_directories(tetgen PRIVATE "${TETGEN_SOURCE_DIR}/src")
+
+            if(MSVC)
+              target_compile_definitions(tetgen PRIVATE NOMINMAX _CRT_SECURE_NO_WARNINGS)
+            endif()
+
+            install(TARGETS tetgen RUNTIME DESTINATION .)
+            """
+        ).strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def build_tetgen_cli(num_cores=None):
+    if num_cores is None:
+        num_cores = os.cpu_count() or 1
+
+    if shutil.which("cmake") is None:
+        raise RuntimeError("CMake is not installed or not on the PATH.")
+
+    download_url_tetgen = os.environ.get(
+        "SVV_TETGEN_CLI_URL",
+        "https://github.com/pyvista/tetgen/archive/refs/tags/v0.8.3.tar.gz",
+    )
+    tarball_path_tetgen = "tetgen-cli.tar.gz"
+    source_extract_root = os.path.abspath("tetgen-cli-src")
+    build_dir_tetgen = os.path.abspath(os.path.join("bin", "tetgen-cli"))
+    wrapper_dir_tetgen = os.path.abspath(os.path.join("bin", "tetgen-cli-wrapper"))
+
+    try:
+        if not os.path.exists(tarball_path_tetgen):
+            print(f"Downloading {download_url_tetgen}...")
+            urlretrieve(download_url_tetgen, tarball_path_tetgen)
+    except Exception as e:
+        raise RuntimeError("Error downloading TetGen CLI archive.") from e
+
+    try:
+        if not os.path.exists(source_extract_root):
+            os.makedirs(source_extract_root, exist_ok=True)
+            with tarfile.open(tarball_path_tetgen, "r:gz") as t:
+                _tar_safe_extract(t, source_extract_root)
+    except Exception as e:
+        raise RuntimeError("Error extracting TetGen CLI archive.") from e
+
+    tetgen_source_dir = _find_tetgen_cli_source_dir(source_extract_root)
+
+    if os.path.isdir(build_dir_tetgen):
+        shutil.rmtree(build_dir_tetgen, ignore_errors=True)
+    if os.path.isdir(wrapper_dir_tetgen):
+        shutil.rmtree(wrapper_dir_tetgen, ignore_errors=True)
+    os.makedirs(build_dir_tetgen, exist_ok=True)
+    os.makedirs(wrapper_dir_tetgen, exist_ok=True)
+    _write_tetgen_cli_cmakelists(os.path.join(wrapper_dir_tetgen, "CMakeLists.txt"))
+
+    cmake_cmd = ["cmake", "-Wno-dev", "-Wno-deprecated"]
+    if platform.system().lower().startswith("win"):
+        vs_generator = pick_visual_studio_generator()
+        if vs_generator:
+            cmake_cmd += ["-G", vs_generator]
+        else:
+            print("No suitable Visual Studio found, falling back to default generator or NMake.")
+
+    cmake_cmd += [
+        "-DCMAKE_BUILD_TYPE=Release",
+        f"-DTETGEN_SOURCE_DIR={tetgen_source_dir}",
+        "-B", build_dir_tetgen,
+        "-S", wrapper_dir_tetgen,
+    ]
+    print("Configuring TetGen CLI with CMake:", " ".join(cmake_cmd))
+    try:
+        subprocess.check_call(cmake_cmd)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError("CMake configure failed for TetGen CLI.") from e
+
+    build_cmd = [
+        "cmake",
+        "--build", build_dir_tetgen,
+        "--parallel", str(num_cores),
+    ]
+    if platform.system().lower().startswith("win"):
+        build_cmd += ["--config", "Release"]
+    print("Building TetGen CLI with CMake:", " ".join(build_cmd))
+    try:
+        subprocess.check_call(build_cmd)
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError("CMake build failed for TetGen CLI.") from e
+
+    os_dir = _tetgen_os_dir()
+    arch_dir = _tetgen_arch_dir(os_dir)
+    install_prefix = os.path.abspath(os.path.join("svv", "utils", "meshing", os_dir, arch_dir))
+    os.makedirs(install_prefix, exist_ok=True)
+    install_cmd = [
+        "cmake",
+        "--install", build_dir_tetgen,
+        "--prefix", install_prefix,
+    ]
+    if platform.system().lower().startswith("win"):
+        install_cmd += ["--config", "Release"]
+    print("Installing TetGen CLI with CMake:", " ".join(install_cmd))
+    subprocess.check_call(install_cmd)
+
+    expected_name = _tetgen_expected_filenames(os_dir, arch_dir)[0]
+    exe_path = Path(install_prefix) / expected_name
+    if not exe_path.is_file():
+        raise RuntimeError(
+            "TetGen CLI build completed, but the staged executable was not found at "
+            f"{exe_path}."
+        )
+    if os_dir != "Windows":
+        exe_path.chmod(exe_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    print(f"TetGen CLI staged at: {exe_path}")
+    print("Remove Source, Archive, and Build directories")
+    if os.path.isfile(tarball_path_tetgen):
+        os.remove(tarball_path_tetgen)
+    remove_directory_tree(build_dir_tetgen)
+    remove_directory_tree(wrapper_dir_tetgen)
+    remove_directory_tree(source_extract_root)
+
+
 def build_0d(num_cores=None):
     if num_cores is None:
         num_cores = os.cpu_count() or 1
@@ -562,12 +770,17 @@ class DownloadAndBuildExt(build_ext):
         (
             "build-native-binaries",
             None,
-            "build and stage MMG + svZeroDSolver executables for this platform",
+            "build and stage MMG + TetGen CLI + svZeroDSolver executables for this platform",
         ),
         (
             "build-mmg",
             None,
             "build and stage MMG executables for this platform",
+        ),
+        (
+            "build-tetgen-cli",
+            None,
+            "build and stage TetGen CLI executable for this platform",
         ),
         (
             "build-solver-0d",
@@ -578,6 +791,7 @@ class DownloadAndBuildExt(build_ext):
     boolean_options = build_ext.boolean_options + [
         "build-native-binaries",
         "build-mmg",
+        "build-tetgen-cli",
         "build-solver-0d",
     ]
 
@@ -585,6 +799,7 @@ class DownloadAndBuildExt(build_ext):
         super().initialize_options()
         self.build_native_binaries = False
         self.build_mmg = False
+        self.build_tetgen_cli = False
         self.build_solver_0d = False
 
     def run(self):
@@ -594,6 +809,11 @@ class DownloadAndBuildExt(build_ext):
             or bool(self.build_native_binaries)
             or bool(self.build_mmg)
         )
+        build_tetgen_cli_flag = (
+            env_flag("SVV_BUILD_TETGEN_CLI", False)
+            or bool(self.build_native_binaries)
+            or bool(self.build_tetgen_cli)
+        )
         build_0d_flag = (
             env_flag("SVV_BUILD_SOLVER_0D", False)
             or env_flag("SVV_BUILD_SOLVERS", False)
@@ -602,11 +822,13 @@ class DownloadAndBuildExt(build_ext):
         )
 
         if self.build_native_binaries:
-            print("Building native binaries: MMG + svZeroDSolver")
-        elif self.build_mmg or self.build_solver_0d:
+            print("Building native binaries: MMG + TetGen CLI + svZeroDSolver")
+        elif self.build_mmg or self.build_tetgen_cli or self.build_solver_0d:
             selected = []
             if self.build_mmg:
                 selected.append("MMG")
+            if self.build_tetgen_cli:
+                selected.append("TetGen CLI")
             if self.build_solver_0d:
                 selected.append("svZeroDSolver")
             print("Building native binaries:", " + ".join(selected))
@@ -616,6 +838,12 @@ class DownloadAndBuildExt(build_ext):
                 build_mmg(num_cores=num_cores)
             except Exception as e:
                 print(f"Warning: MMG build failed ({e}). Continuing without building MMG.")
+
+        if build_tetgen_cli_flag:
+            try:
+                build_tetgen_cli(num_cores=num_cores)
+            except Exception as e:
+                print(f"Warning: TetGen CLI build failed ({e}). Continuing without building TetGen CLI.")
 
         if build_0d_flag:
             try:
@@ -806,6 +1034,7 @@ def _mmg_expected_filenames(os_dir: str, arch_dir: str) -> list:
     return names
 
 
+
 def _mmg_package_patterns() -> list:
     if ACCEL_COMPANION:
         return []
@@ -820,6 +1049,26 @@ def _mmg_package_patterns() -> list:
         if missing:
             raise RuntimeError(
                 "MMG executables missing for this build. "
+                f"Expected in {base}:\n  - " + "\n  - ".join(missing)
+            )
+
+    return [f"{os_dir}/{arch_dir}/*"]
+
+
+def _tetgen_package_patterns() -> list:
+    if ACCEL_COMPANION:
+        return []
+
+    os_dir = _tetgen_os_dir()
+    arch_dir = _tetgen_arch_dir(os_dir)
+
+    if env_flag("SVV_REQUIRE_TETGEN_CLI", False):
+        repo_root = Path(__file__).resolve().parent
+        base = repo_root / "svv" / "utils" / "meshing" / os_dir / arch_dir
+        missing = [n for n in _tetgen_expected_filenames(os_dir, arch_dir) if not (base / n).is_file()]
+        if missing:
+            raise RuntimeError(
+                "TetGen CLI executable missing for this build. "
                 f"Expected in {base}:\n  - " + "\n  - ".join(missing)
             )
 
@@ -924,6 +1173,7 @@ setup_info = dict(
                 'icons/*.svg',
             ],
             'svv.utils.remeshing': _mmg_package_patterns(),
+            'svv.utils.meshing': _tetgen_package_patterns(),
             'svv.utils.solvers': _solver_0d_package_patterns(),
         }
         if not ACCEL_COMPANION

--- a/svv/domain/io/read.py
+++ b/svv/domain/io/read.py
@@ -39,8 +39,10 @@ def read(data, **kwargs):
 
     data = data.compute_normals(split_vertices=True, feature_angle=feature_angle)
 
-    points = data.points.astype(numpy.float64)
-    normals = data.point_normals.astype(numpy.float64)
+    # Materialize base NumPy arrays here so downstream allocation does not pay
+    # pyvista_ndarray adapter overhead on every slice/index operation.
+    points = numpy.array(data.points, dtype=numpy.float64, copy=True)
+    normals = numpy.array(data.point_normals, dtype=numpy.float64, copy=True)
     n = points.shape[0]
     d = points.shape[1]
     return points, normals, n, d

--- a/svv/domain/routines/tetgen_constrained.py
+++ b/svv/domain/routines/tetgen_constrained.py
@@ -1,0 +1,393 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pyvista as pv
+from scipy.spatial import cKDTree
+
+from svv.utils.meshing.tetgen import get_packaged_tetgen_cli_path
+
+
+def resolve_tetgen_exe(tetgen_exe=None):
+    if tetgen_exe:
+        exe = Path(tetgen_exe).expanduser()
+        if exe.is_file():
+            return str(exe)
+        raise RuntimeError(f"TetGen executable not found: {tetgen_exe}")
+
+    env_path = os.environ.get("SVV_TETGEN_PATH")
+    if env_path:
+        exe = Path(env_path).expanduser()
+        if exe.is_file():
+            return str(exe)
+
+    packaged = get_packaged_tetgen_cli_path()
+    if packaged:
+        return packaged
+
+    found = shutil.which("tetgen")
+    if found:
+        return found
+
+    raise RuntimeError(
+        "TetGen executable not found. Set tetgen_exe=..., set SVV_TETGEN_PATH, build the packaged CLI with "
+        "`python setup.py build_ext --build-tetgen-cli`, or install tetgen on PATH."
+    )
+
+
+def _iter_data_lines(path):
+    with open(path, "r", encoding="utf-8", errors="ignore") as stream:
+        for line in stream:
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                yield stripped
+
+
+def write_poly(surface, path):
+    surface = surface.extract_surface().triangulate()
+    if not surface.is_all_triangles:
+        raise ValueError("TetGen PLC export requires an all-triangle surface mesh.")
+
+    faces = surface.faces.reshape(-1, 4)[:, 1:]
+    with open(path, "w", encoding="utf-8") as stream:
+        stream.write(f"{surface.n_points} 3 0 0\n")
+        for idx, point in enumerate(surface.points, start=1):
+            stream.write(f"{idx} {point[0]} {point[1]} {point[2]}\n")
+
+        stream.write(f"{faces.shape[0]} 0\n")
+        for tri in faces:
+            stream.write("1 0 0\n")
+            stream.write(f"3 {int(tri[0]) + 1} {int(tri[1]) + 1} {int(tri[2]) + 1}\n")
+
+        stream.write("0\n")
+        stream.write("0\n")
+
+
+def write_a_node(points, path):
+    points = np.asarray(points, dtype=float).reshape(-1, 3)
+    with open(path, "w", encoding="utf-8") as stream:
+        stream.write(f"{points.shape[0]} 3 0 0\n")
+        for idx, point in enumerate(points, start=1):
+            stream.write(f"{idx} {point[0]} {point[1]} {point[2]}\n")
+
+
+def run_tetgen(exe, switches, stem, cwd):
+    cmd = [exe, f"-{switches}", stem]
+    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"TetGen failed with code {result.returncode}\n"
+            f"Command: {' '.join(cmd)}\n"
+            f"STDOUT:\n{result.stdout}\n\nSTDERR:\n{result.stderr}"
+        )
+
+
+def read_node(path):
+    line_iter = iter(_iter_data_lines(path))
+    header = next(line_iter).split()
+    n_points = int(header[0])
+    dim = int(header[1])
+    if dim != 3:
+        raise ValueError(f"Expected 3D TetGen nodes, got dimension {dim}.")
+
+    points = np.zeros((n_points, dim), dtype=float)
+    index_map = {}
+    for row in range(n_points):
+        parts = next(line_iter).split()
+        node_id = int(parts[0])
+        points[row, :] = [float(parts[1]), float(parts[2]), float(parts[3])]
+        index_map[node_id] = row
+    return points, index_map
+
+
+def read_ele(path, index_map):
+    line_iter = iter(_iter_data_lines(path))
+    header = next(line_iter).split()
+    n_cells = int(header[0])
+    nodes_per_cell = int(header[1])
+
+    elems = np.zeros((n_cells, nodes_per_cell), dtype=np.int64)
+    for row in range(n_cells):
+        parts = next(line_iter).split()
+        node_ids = [int(value) for value in parts[1:1 + nodes_per_cell]]
+        elems[row, :] = [index_map[node_id] for node_id in node_ids]
+    return elems
+
+
+def _normalize_point_metadata(point_metadata, point_count):
+    normalized = {}
+    for name, values in (point_metadata or {}).items():
+        array = np.asarray(values).reshape(-1)
+        if array.shape[0] != point_count:
+            raise ValueError(
+                f"Point metadata '{name}' must have length {point_count}, got {array.shape[0]}."
+            )
+        normalized[name] = array
+    return normalized
+
+
+def _relative_enclosure_tolerance(surface, verify_tol):
+    bounds = np.asarray(surface.bounds, dtype=float)
+    spans = bounds[1::2] - bounds[::2]
+    diagonal = float(np.linalg.norm(spans))
+    if not np.isfinite(diagonal) or diagonal <= 0.0:
+        return 1e-9
+
+    abs_tol = max(float(verify_tol), 0.0)
+    if abs_tol <= 0.0:
+        abs_tol = diagonal * 1e-9
+
+    rel_tol = abs_tol / diagonal
+    return min(max(rel_tol * 10.0, 1e-12), 1e-4)
+
+
+def filter_prescribed_points_to_surface(
+    surface,
+    prescribed_points,
+    prescribed_lines=None,
+    *,
+    point_metadata=None,
+    verify_tol=1e-6,
+):
+    prescribed_points = np.asarray(prescribed_points, dtype=float).reshape(-1, 3)
+    prescribed_lines = (
+        np.empty((0, 2), dtype=np.int64)
+        if prescribed_lines is None
+        else np.asarray(prescribed_lines, dtype=np.int64).reshape(-1, 2)
+    )
+    point_metadata = _normalize_point_metadata(point_metadata, prescribed_points.shape[0])
+
+    if prescribed_points.shape[0] == 0:
+        return {
+            "points": prescribed_points,
+            "lines": prescribed_lines,
+            "point_metadata": point_metadata,
+            "kept_point_ids": np.empty((0,), dtype=np.int64),
+            "dropped_point_ids": np.empty((0,), dtype=np.int64),
+        }
+
+    surface_mesh = surface.extract_surface().triangulate().clean()
+    if surface_mesh.n_points == 0 or surface_mesh.n_cells == 0:
+        raise ValueError("Cannot filter prescribed points against an empty tissue surface mesh.")
+
+    selector = pv.PolyData(prescribed_points)
+    selected = selector.select_enclosed_points(
+        surface_mesh,
+        tolerance=_relative_enclosure_tolerance(surface_mesh, verify_tol),
+        check_surface=True,
+    )
+    inside_mask = np.asarray(selected["SelectedPoints"]).reshape(-1).astype(bool)
+    kept_point_ids = np.flatnonzero(inside_mask)
+    dropped_point_ids = np.flatnonzero(~inside_mask)
+
+    if kept_point_ids.size == 0:
+        raise RuntimeError(
+            "No prescribed spline points lie inside the tissue domain after filtering. "
+            f"Dropped {dropped_point_ids.size} of {prescribed_points.shape[0]} points."
+        )
+
+    old_to_new = np.full(prescribed_points.shape[0], -1, dtype=np.int64)
+    old_to_new[kept_point_ids] = np.arange(kept_point_ids.size, dtype=np.int64)
+
+    remapped_lines = []
+    seen_lines = set()
+    for line in prescribed_lines:
+        start = int(old_to_new[int(line[0])])
+        end = int(old_to_new[int(line[1])])
+        if start < 0 or end < 0 or start == end:
+            continue
+        key = (start, end)
+        if key in seen_lines:
+            continue
+        seen_lines.add(key)
+        remapped_lines.append([start, end])
+
+    filtered_metadata = {
+        name: np.asarray(values)[kept_point_ids]
+        for name, values in point_metadata.items()
+    }
+
+    return {
+        "points": prescribed_points[kept_point_ids],
+        "lines": np.asarray(remapped_lines, dtype=np.int64).reshape(-1, 2),
+        "point_metadata": filtered_metadata,
+        "kept_point_ids": kept_point_ids,
+        "dropped_point_ids": dropped_point_ids,
+    }
+
+
+def verify_prescribed_points(nodes, prescribed_points, tol):
+    nodes = np.asarray(nodes, dtype=float).reshape(-1, 3)
+    if nodes.shape[0] == 0:
+        raise RuntimeError("TetGen output mesh has no nodes to verify prescribed spline points.")
+
+    tree = cKDTree(nodes)
+    distances, node_ids = tree.query(np.asarray(prescribed_points, dtype=float).reshape(-1, 3))
+    distances = np.asarray(distances, dtype=float)
+    node_ids = np.asarray(node_ids, dtype=np.int64)
+    if np.any(distances > tol):
+        failing = np.flatnonzero(distances > tol)
+        preview = failing[:20].tolist()
+        preview_suffix = "" if failing.size <= 20 else f" (showing first 20 of {failing.size})"
+        max_distance = float(distances[failing].max())
+        raise RuntimeError(
+            "TetGen output does not contain all prescribed spline points within tolerance. "
+            f"Tolerance: {tol:g}. Failed point ids: {preview}{preview_suffix}. "
+            f"Max miss distance: {max_distance:.6g}"
+        )
+    return node_ids, distances
+
+
+def attach_constraint_metadata(
+    grid,
+    node_ids,
+    point_metadata=None,
+    line_count=0,
+    original_point_count=None,
+    dropped_point_count=0,
+    unique_node_count=None,
+    max_assignment_distance=0.0,
+    tolerance_exceeded_count=0,
+):
+    point_metadata = point_metadata or {}
+    node_ids = np.asarray(node_ids, dtype=np.int64).reshape(-1)
+
+    centerline_node = np.zeros(grid.n_points, dtype=np.uint8)
+    centerline_spline_id = np.full(grid.n_points, -1, dtype=np.int32)
+    centerline_spline_order = np.full(grid.n_points, -1, dtype=np.int32)
+    centerline_radius = np.full(grid.n_points, np.nan, dtype=float)
+
+    centerline_node[node_ids] = 1
+    if "spline_id" in point_metadata:
+        centerline_spline_id[node_ids] = np.asarray(point_metadata["spline_id"], dtype=np.int32)
+    if "spline_order" in point_metadata:
+        centerline_spline_order[node_ids] = np.asarray(point_metadata["spline_order"], dtype=np.int32)
+    if "radius" in point_metadata:
+        centerline_radius[node_ids] = np.asarray(point_metadata["radius"], dtype=float)
+
+    if original_point_count is None:
+        original_point_count = node_ids.shape[0] + int(dropped_point_count)
+    if unique_node_count is None:
+        unique_node_count = np.unique(node_ids).shape[0]
+
+    # Preserve the older centerline-specific name and add a generic alias for
+    # all constraint sources, including explicit prescribed points.
+    grid.point_data["constrained_point"] = centerline_node.copy()
+    grid.point_data["centerline_node"] = centerline_node
+    grid.point_data["centerline_spline_id"] = centerline_spline_id
+    grid.point_data["centerline_spline_order"] = centerline_spline_order
+    grid.point_data["centerline_radius"] = centerline_radius
+    grid.field_data["centerline_constraint_count"] = np.array([node_ids.shape[0]], dtype=np.int32)
+    grid.field_data["centerline_constraint_line_count"] = np.array([int(line_count)], dtype=np.int32)
+    grid.field_data["centerline_constraint_original_count"] = np.array([int(original_point_count)], dtype=np.int32)
+    grid.field_data["centerline_constraint_dropped_count"] = np.array([int(dropped_point_count)], dtype=np.int32)
+    grid.field_data["centerline_constraint_unique_node_count"] = np.array([int(unique_node_count)], dtype=np.int32)
+    grid.field_data["centerline_constraint_assignment_max_distance"] = np.array([float(max_assignment_distance)], dtype=float)
+    grid.field_data["centerline_constraint_tolerance_exceeded_count"] = np.array([int(tolerance_exceeded_count)], dtype=np.int32)
+
+
+def _cell_types(nodes_per_cell, n_cells):
+    if nodes_per_cell == 4:
+        return np.full(n_cells, pv.CellType.TETRA, dtype=np.uint8)
+    if nodes_per_cell == 10:
+        return np.full(n_cells, pv.CellType.QUADRATIC_TETRA, dtype=np.uint8)
+    raise ValueError(f"Unexpected number of vertices per TetGen element: {nodes_per_cell}")
+
+
+def tetrahedralize_with_prescribed_points(
+    surface,
+    prescribed_points,
+    prescribed_lines=None,
+    *,
+    minratio=1.1,
+    mindihedral=10.0,
+    order=1,
+    verify_tol=1e-6,
+    tetgen_exe=None,
+    point_metadata=None,
+):
+    prescribed_points = np.asarray(prescribed_points, dtype=float).reshape(-1, 3)
+    if prescribed_points.shape[0] == 0:
+        raise ValueError("tetrahedralize_with_prescribed_points requires at least one prescribed point.")
+
+    prescribed_lines = (
+        np.empty((0, 2), dtype=np.int64)
+        if prescribed_lines is None
+        else np.asarray(prescribed_lines, dtype=np.int64).reshape(-1, 2)
+    )
+    point_metadata = _normalize_point_metadata(point_metadata, prescribed_points.shape[0])
+    filtered = filter_prescribed_points_to_surface(
+        surface,
+        prescribed_points,
+        prescribed_lines,
+        point_metadata=point_metadata,
+        verify_tol=verify_tol,
+    )
+
+    filtered_points = filtered["points"]
+    filtered_lines = filtered["lines"]
+    filtered_metadata = filtered["point_metadata"]
+    dropped_point_ids = filtered["dropped_point_ids"]
+
+    exe = resolve_tetgen_exe(tetgen_exe)
+    order_switch = "o2" if int(order) == 2 else ""
+    quality_switches = f"q{minratio}/{mindihedral}{order_switch}"
+
+    with tempfile.TemporaryDirectory(prefix="svv_tetgen_constraints_") as tmpdir:
+        tmpdir_path = Path(tmpdir)
+        base_name = "surface"
+        poly_path = tmpdir_path / f"{base_name}.poly"
+        write_poly(surface, poly_path)
+
+        run_tetgen(exe, f"p{quality_switches}Q", poly_path.name, tmpdir)
+
+        insert_path = tmpdir_path / f"{base_name}.1.a.node"
+        write_a_node(filtered_points, insert_path)
+        run_tetgen(exe, f"ri{order_switch}JMQ", f"{base_name}.1", tmpdir)
+
+        node_path = tmpdir_path / f"{base_name}.2.node"
+        ele_path = tmpdir_path / f"{base_name}.2.ele"
+        nodes, index_map = read_node(node_path)
+        elems = read_ele(ele_path, index_map)
+
+    n_cells, n_vertices_per_cell = elems.shape
+    cells = np.hstack(
+        [
+            np.full((n_cells, 1), n_vertices_per_cell, dtype=np.int64),
+            elems.astype(np.int64),
+        ]
+    ).ravel()
+    celltypes = _cell_types(n_vertices_per_cell, n_cells)
+    grid = pv.UnstructuredGrid(cells, celltypes, nodes)
+
+    node_ids, distances = verify_prescribed_points(nodes, filtered_points, verify_tol)
+    unique_node_count = np.unique(node_ids).shape[0]
+    max_assignment_distance = float(distances.max()) if distances.size else 0.0
+
+    attach_constraint_metadata(
+        grid,
+        node_ids,
+        point_metadata=filtered_metadata,
+        line_count=filtered_lines.shape[0],
+        original_point_count=prescribed_points.shape[0],
+        dropped_point_count=dropped_point_ids.shape[0],
+        unique_node_count=unique_node_count,
+        max_assignment_distance=max_assignment_distance,
+        tolerance_exceeded_count=0,
+    )
+
+    return grid, nodes, elems, {
+        "node_ids": node_ids,
+        "distances": distances,
+        "line_count": int(filtered_lines.shape[0]),
+        "original_point_count": int(prescribed_points.shape[0]),
+        "retained_point_count": int(filtered_points.shape[0]),
+        "dropped_point_count": int(dropped_point_ids.shape[0]),
+        "dropped_point_ids": dropped_point_ids.tolist(),
+        "unique_node_count": int(unique_node_count),
+        "max_assignment_distance": max_assignment_distance,
+        "insertion_switches": f"ri{order_switch}JMQ",
+    }

--- a/svv/forest/forest.py
+++ b/svv/forest/forest.py
@@ -9,7 +9,7 @@ from svv.tree.utils.TreeManager import KDTreeManager, USearchTree
 from svv.forest.connect.geodesic import geodesic_constructor
 from svv.forest.connect.forest_connection import ForestConnection
 from svv.visualize.forest.show import show
-from svv.forest.export.export_spline import export_spline, write_splines
+from svv.forest.export.export_spline import export_spline, write_splines as write_forest_splines
 
 
 class Forest(object):
@@ -388,18 +388,28 @@ class Forest(object):
                 if os.path.exists(tmp_path):
                     os.replace(tmp_path, dst_path)
 
-    def export_splines(self, outdir=None):
+    def export_splines(self, outdir=None, spline_sample_points=100, write_splines=True):
         """
         Export networks splines
         """
+        all_splines = []
         if isinstance(outdir, type(None)):
             outdir = 'splines_tmp'
-            if not os.path.exists(outdir):
+            if write_splines and not os.path.exists(outdir):
                 os.makedirs(outdir)
         if not isinstance(self.connections, type(None)):
             for i in range(len(self.connections.tree_connections)):
                 interp_xyz, interp_radii, interp_normals, all_points, all_radii, all_normals = export_spline(self.connections.tree_connections[i])
-                _ = write_splines(all_points, all_radii, outdir=outdir, name_prefix="{}".format(i))
+                network_splines = write_forest_splines(
+                    all_points,
+                    all_radii,
+                    spline_sample_points=spline_sample_points,
+                    outdir=outdir,
+                    name_prefix="{}".format(i),
+                    write_splines=write_splines,
+                )
+                all_splines.append(network_splines)
+        return all_splines
 
     def save(self, path: str, include_timing: bool = False):
         """

--- a/svv/simulation/simulation.py
+++ b/svv/simulation/simulation.py
@@ -23,6 +23,8 @@ from svv.simulation.mesh import GeneralMesh
 from svv.simulation.fluid.fluid_equation import FluidEquation
 from svv.simulation.utils.boundary_layer import BoundaryLayer
 from svv.domain.routines.tetrahedralize import tetrahedralize
+from svv.domain.routines.tetgen_constrained import tetrahedralize_with_prescribed_points
+from svv.simulation.utils.spline_constraints import deduplicate_spline_constraints, sample_spline_functions
 
 # Defer 1D/0D ROM imports to their respective methods to avoid importing
 # vtk-heavy modules during Simulation class import.
@@ -53,6 +55,7 @@ class Simulation(object):
         self.fluid_domain_boundary_layers = []
         self.fluid_domain_interiors = []
         self.fluid_domain_wall_layers = []
+        self.tissue_constraint_metadata = []
         if isinstance(self.synthetic_object, svv.tree.tree.Tree):
             self.fluid_3d_simulations = [None]
             self.fluid_1d_simulations = [None]
@@ -84,10 +87,126 @@ class Simulation(object):
             resolved_folder = target.name or default_folder
         return resolved_outdir, resolved_folder, os.path.join(resolved_outdir, resolved_folder)
 
+    @staticmethod
+    def _uses_spline_point_constraints(tissue_mesh_type):
+        mesh_type = str(tissue_mesh_type).strip().lower()
+        return mesh_type in {"spline_point_constrained", "centerline_point_constrained"}
+
+    def _remesh_tissue_boundary(self, boundary, **kwargs):
+        remesh_kwargs = dict(kwargs)
+        remesh_kwargs.setdefault("verbosity", 0)
+        try:
+            return remesh_surface(boundary, **remesh_kwargs)
+        except Exception:
+            fix = pymeshfix.MeshFix(boundary)
+            fix.repair()
+            return remesh_surface(fix.mesh, **remesh_kwargs)
+
+    @staticmethod
+    def _boundary_is_manifold(boundary):
+        try:
+            return bool(boundary.is_manifold)
+        except Exception:
+            return False
+
+    def _prepare_constrained_tissue_boundary(self, boundary, **kwargs):
+        if self._boundary_is_manifold(boundary):
+            return boundary.copy(deep=True)
+        return self._remesh_tissue_boundary(boundary, **kwargs)
+
+    def _collect_tissue_spline_constraints(self, *, tree=None, tissue_constraint_points=None,
+                                           tissue_constraint_lines=None,
+                                           tissue_constraint_spline_sample_points=100,
+                                           tissue_constraint_tolerance=1e-6):
+        if tissue_constraint_points is not None:
+            sampled = {
+                "points": numpy.asarray(tissue_constraint_points, dtype=float).reshape(-1, 3),
+                "lines": (
+                    numpy.empty((0, 2), dtype=numpy.int64)
+                    if tissue_constraint_lines is None
+                    else numpy.asarray(tissue_constraint_lines, dtype=numpy.int64).reshape(-1, 2)
+                ),
+            }
+            sampled["spline_id"] = numpy.full(sampled["points"].shape[0], -1, dtype=numpy.int32)
+            sampled["spline_order"] = numpy.arange(sampled["points"].shape[0], dtype=numpy.int32)
+            sampled["radius"] = numpy.full(sampled["points"].shape[0], numpy.nan, dtype=float)
+        else:
+            if tree is not None:
+                splines = tree.export_splines(
+                    spline_sample_points=tissue_constraint_spline_sample_points,
+                    write_splines=False,
+                )
+            elif isinstance(self.synthetic_object, svv.tree.tree.Tree):
+                splines = self.synthetic_object.export_splines(
+                    spline_sample_points=tissue_constraint_spline_sample_points,
+                    write_splines=False,
+                )
+            elif isinstance(self.synthetic_object, svv.forest.forest.Forest) and not isinstance(self.synthetic_object.connections, type(None)):
+                splines = self.synthetic_object.export_splines(
+                    spline_sample_points=tissue_constraint_spline_sample_points,
+                    write_splines=False,
+                )
+            else:
+                raise ValueError(
+                    "Automatic spline constraint collection requires a tree or connected forest object."
+                )
+            sampled = sample_spline_functions(
+                splines,
+                spline_sample_points=tissue_constraint_spline_sample_points,
+            )
+
+        return deduplicate_spline_constraints(
+            sampled["points"],
+            lines=sampled.get("lines"),
+            spline_id=sampled.get("spline_id"),
+            spline_order=sampled.get("spline_order"),
+            radius=sampled.get("radius"),
+            tol=max(float(tissue_constraint_tolerance), 0.0),
+        )
+
+    def _build_constrained_tissue_volume_mesh(self, tissue_domain, *, constraint_data, minratio=1.1,
+                                              mindihedral=10.0, order=1,
+                                              tissue_constraint_tolerance=1e-6, tetgen_exe=None):
+        if constraint_data is None or constraint_data["points"].shape[0] == 0:
+            raise ValueError("Spline-point-constrained tissue meshing requires at least one prescribed point.")
+
+        point_metadata = {
+            "spline_id": constraint_data["spline_id"],
+            "spline_order": constraint_data["spline_order"],
+            "radius": constraint_data["radius"],
+        }
+
+        def _mesh(surface_mesh):
+            return tetrahedralize_with_prescribed_points(
+                surface_mesh,
+                constraint_data["points"],
+                prescribed_lines=constraint_data["lines"],
+                minratio=minratio,
+                mindihedral=mindihedral,
+                order=order,
+                verify_tol=tissue_constraint_tolerance,
+                tetgen_exe=tetgen_exe,
+                point_metadata=point_metadata,
+            )
+
+        try:
+            return _mesh(tissue_domain)
+        except Exception as exc:
+            if "TetGen executable not found" in str(exc):
+                raise
+            if self._boundary_is_manifold(tissue_domain):
+                raise
+            fix = pymeshfix.MeshFix(tissue_domain)
+            fix.repair()
+            return _mesh(fix.mesh)
+
     def build_meshes(self, fluid=True, tissue=False, hausd=0.0001, hsize=None, minratio=1.1, mindihedral=10.0,
                      order=1, remesh_vol=False, boundary_layer=True, layer_thickness_ratio=0.25,
                      layer_thickness_ratio_adjustment=0.5, boundary_layer_attempts=5, wall_layers=False,
-                     wall_thickness=None, upper_num_triangles=1000, lower_num_triangles=100):
+                     wall_thickness=None, upper_num_triangles=1000, lower_num_triangles=100,
+                     tissue_mesh_type="standard", tissue_constraint_points=None, tissue_constraint_lines=None,
+                     tissue_constraint_spline_sample_points=100, tissue_constraint_tolerance=1e-6,
+                     tetgen_exe=None):
         """
         Build the mesh objects for 3D simulations.
         :return:
@@ -102,9 +221,11 @@ class Simulation(object):
         self.fluid_domain_boundary_layers = []
         self.fluid_domain_interiors = []
         self.fluid_domain_wall_layers = []
+        self.tissue_constraint_metadata = []
+        uses_spline_constraints = self._uses_spline_point_constraints(tissue_mesh_type)
         if isinstance(self.synthetic_object, svv.tree.tree.Tree):
             if fluid:
-                if tissue:
+                if tissue and not uses_spline_constraints:
                     extension_scale = 4.0
                     for i in range(5):
                         new_root = self.synthetic_object.data[0, 0:3] + extension_scale * self.synthetic_object.data[0, 21]*self.synthetic_object.data.get('w_basis', 0)
@@ -195,63 +316,89 @@ class Simulation(object):
                     fluid_surface_mesh.cell_data["hsize"][0] = hsize
                     self.fluid_domain_surface_meshes.append(fluid_surface_mesh)
                     self.fluid_domain_volume_meshes.append(fluid_volume_mesh)
-                    if tissue:
+                    if tissue and not uses_spline_constraints:
                         self.synthetic_object.data[0, 0:3] += root_extension * self.synthetic_object.data.get('w_basis',0)
             if tissue and not isinstance(self.synthetic_object.domain, type(None)):
-                # Extrude the root of the tree to ensure proper intersection with the tissue domain.
-                if not fluid:
-                    root_extension = max(self.synthetic_object.data[0, 21] * 4, self.synthetic_object.data[0, 20] * 0.5)
-                    self.synthetic_object.data[0, 0:3] += root_extension * self.synthetic_object.data.get('w_basis', 0)
-                    # Should check to see that the extended point does not intersect with another fluid or tissue domain.
-                    fluid_surface_boolean_mesh = self.synthetic_object.export_solid(watertight=True)
+                if uses_spline_constraints:
+                    tissue_domain = self._prepare_constrained_tissue_boundary(
+                        self.synthetic_object.domain.boundary,
+                        hausd=hausd,
+                    )
                 else:
-                    if not wall_layers:
-                        fluid_surface_boolean_mesh = deepcopy(self.fluid_domain_surface_meshes[-1])
+                    # Extrude the root of the tree to ensure proper intersection with the tissue domain.
+                    if not fluid:
+                        root_extension = max(self.synthetic_object.data[0, 21] * 4, self.synthetic_object.data[0, 20] * 0.5)
+                        self.synthetic_object.data[0, 0:3] += root_extension * self.synthetic_object.data.get('w_basis', 0)
+                        # Should check to see that the extended point does not intersect with another fluid or tissue domain.
+                        fluid_surface_boolean_mesh = self.synthetic_object.export_solid(watertight=True)
                     else:
-                        fluid_surface_boolean_mesh = deepcopy(self.fluid_domain_wall_layers[-1])
-                hsize = fluid_surface_boolean_mesh.cell_data["hsize"][0]
-                try:
-                    tissue_domain = remesh_surface(self.synthetic_object.domain.boundary, hausd=hausd, verbosity=0) # Check if this should be remeshed
-                except:
-                    print("REMESHING FAILS: CHECKING FOR TRIANGLE INTERSECTIONS")
-                    tmp_boundary = pymeshfix.MeshFix(self.synthetic_object.domain.boundary)
-                area = tissue_domain.area
-                tissue_domain = boolean(tissue_domain, fluid_surface_boolean_mesh, operation='difference')
-                if fluid:
-                    fluid_faces = extract_faces(tissue_domain, None)
-                    face_sizes = [len(face) for face in fluid_faces[0]]
-                    wall = numpy.argmax(face_sizes)
-                    low_tri_area = area / upper_num_triangles
-                    hmin = ((4.0*low_tri_area)/3.0**0.5) ** (0.5)
-                    upper_tri_area = area / lower_num_triangles
-                    hmax = ((4.0*upper_tri_area)/3.0**0.5) ** (0.5)
-                    tissue_domain = remesh_surface(tissue_domain, hausd=hausd, verbosity=0)
-                else:
-                    tissue_domain = remesh_surface(tissue_domain, hausd=hausd, verbosity=0)
-                #tet_tissue = tetgen.TetGen(tissue_domain)
-                if not fluid:
-                    self.synthetic_object.data[0, 0:3] += root_extension * self.synthetic_object.data.get('w_basis', 0)
-                try:
-                    grid, nodes, elems = tetrahedralize(switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
-                    #tet_tissue.tetrahedralize(minratio=minratio, order=order)
-                    tissue_volume_mesh = grid
-                except:
+                        if not wall_layers:
+                            fluid_surface_boolean_mesh = deepcopy(self.fluid_domain_surface_meshes[-1])
+                        else:
+                            fluid_surface_boolean_mesh = deepcopy(self.fluid_domain_wall_layers[-1])
+                    hsize = fluid_surface_boolean_mesh.cell_data["hsize"][0]
+                    tissue_domain = self._remesh_tissue_boundary(
+                        self.synthetic_object.domain.boundary,
+                        hausd=hausd,
+                    )
+                    area = tissue_domain.area
+                    tissue_domain = boolean(tissue_domain, fluid_surface_boolean_mesh, operation='difference')
                     if fluid:
-                        print('Mesh interface may be corrupted after mesh fixing for tetrahedralization.')
-                    fix = pymeshfix.MeshFix(tissue_domain)
-                    fix.repair()
-                    #tet_tissue.make_manifold(verbose=True)
-                    #tet_tissue.tetrahedralize(minratio=minratio, order=order)
-                    grid, nodes, elems = tetrahedralize(fix.mesh, switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
+                        fluid_faces = extract_faces(tissue_domain, None)
+                        face_sizes = [len(face) for face in fluid_faces[0]]
+                        wall = numpy.argmax(face_sizes)
+                        low_tri_area = area / upper_num_triangles
+                        hmin = ((4.0*low_tri_area)/3.0**0.5) ** (0.5)
+                        upper_tri_area = area / lower_num_triangles
+                        hmax = ((4.0*upper_tri_area)/3.0**0.5) ** (0.5)
+                        tissue_domain = self._remesh_tissue_boundary(tissue_domain, hausd=hausd)
+                    else:
+                        tissue_domain = self._remesh_tissue_boundary(tissue_domain, hausd=hausd)
+                    #tet_tissue = tetgen.TetGen(tissue_domain)
+                    if not fluid:
+                        self.synthetic_object.data[0, 0:3] += root_extension * self.synthetic_object.data.get('w_basis', 0)
+                if self._uses_spline_point_constraints(tissue_mesh_type):
+                    constraint_data = self._collect_tissue_spline_constraints(
+                        tissue_constraint_points=tissue_constraint_points,
+                        tissue_constraint_lines=tissue_constraint_lines,
+                        tissue_constraint_spline_sample_points=tissue_constraint_spline_sample_points,
+                        tissue_constraint_tolerance=tissue_constraint_tolerance,
+                    )
+                    grid, nodes, elems, constraint_meta = self._build_constrained_tissue_volume_mesh(
+                        tissue_domain,
+                        constraint_data=constraint_data,
+                        minratio=minratio,
+                        mindihedral=mindihedral,
+                        order=order,
+                        tissue_constraint_tolerance=tissue_constraint_tolerance,
+                        tetgen_exe=tetgen_exe,
+                    )
                     tissue_volume_mesh = grid
+                else:
+                    constraint_meta = None
+                    try:
+                        grid, nodes, elems = tetrahedralize(tissue_domain, switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
+                        #tet_tissue.tetrahedralize(minratio=minratio, order=order)
+                        tissue_volume_mesh = grid
+                    except:
+                        if fluid:
+                            print('Mesh interface may be corrupted after mesh fixing for tetrahedralization.')
+                        fix = pymeshfix.MeshFix(tissue_domain)
+                        fix.repair()
+                        #tet_tissue.make_manifold(verbose=True)
+                        #tet_tissue.tetrahedralize(minratio=minratio, order=order)
+                        grid, nodes, elems = tetrahedralize(fix.mesh, switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
+                        tissue_volume_mesh = grid
                 if isinstance(tissue_volume_mesh, type(None)):
                     print("Failed to generate tissue volume mesh.")
+                    self.tissue_constraint_metadata.append(None)
                 else:
                     if remesh_vol:
                         tissue_volume_mesh = remesh_volume(tissue_volume_mesh, hausd=hausd, nosurf=True)
                     tissue_domain = tissue_volume_mesh.extract_surface()
                     self.tissue_domain_surface_meshes.append(tissue_domain)
                     self.tissue_domain_volume_meshes.append(tissue_volume_mesh)
+                    self.tissue_constraint_metadata.append(constraint_meta)
         elif isinstance(self.synthetic_object, svv.forest.forest.Forest) and isinstance(self.synthetic_object.connections, type(None)):
             for network in self.synthetic_object.networks:
                 network_fluid_surface_meshes = []
@@ -286,51 +433,82 @@ class Simulation(object):
                             network_fluid_surface_meshes.append(fluid_surface_mesh)
                             network_fluid_volume_meshes.append(fluid_volume_mesh)
                     if tissue:
-                        # Extrude the root of the tree to ensure proper intersection with the tissue domain.
-                        root_extension = max(tree.data[0, 21] * 4, tree.data[0, 20] * 0.5)
-                        tree.data[0, 0:3] += root_extension * tree.data.get('w_basis', 0)
-                        # Should check to see that the extended point does not intersect with another fluid or tissue domain.
-                        fluid_surface_boolean_mesh = tree.export_solid(watertight=True)
-                        if len(self.tissue_domain_surface_meshes) > 0:
-                            tissue_domain = self.tissue_domain_surface_meshes[-1]
+                        constraint_meta = None
+                        if uses_spline_constraints:
+                            if remesh_tissue_surface:
+                                tissue_domain = self._prepare_constrained_tissue_boundary(
+                                    tree.domain.boundary,
+                                    hausd=hausd,
+                                )
+                            else:
+                                tissue_domain = tree.domain.boundary.copy(deep=True)
                         else:
-                            tissue_domain = tree.domain.boundary
-                        tissue_domain = boolean(tissue_domain, fluid_surface_boolean_mesh, operation='difference')
-                        tissue_domain = remesh_surface(tissue_domain, hausd=hausd, verbosity=0)
+                            # Extrude the root of the tree to ensure proper intersection with the tissue domain.
+                            root_extension = max(tree.data[0, 21] * 4, tree.data[0, 20] * 0.5)
+                            tree.data[0, 0:3] += root_extension * tree.data.get('w_basis', 0)
+                            # Should check to see that the extended point does not intersect with another fluid or tissue domain.
+                            fluid_surface_boolean_mesh = tree.export_solid(watertight=True)
+                            if len(self.tissue_domain_surface_meshes) > 0:
+                                tissue_domain = self.tissue_domain_surface_meshes[-1]
+                            else:
+                                tissue_domain = tree.domain.boundary
+                            tissue_domain = boolean(tissue_domain, fluid_surface_boolean_mesh, operation='difference')
+                            tissue_domain = self._remesh_tissue_boundary(tissue_domain, hausd=hausd)
                         #tet_tissue = tetgen.TetGen(tissue_domain)
                         #tree.data[0, 0:3] += root_extension * tree.data.get('w_basis', 0)
-                        try:
-                            # tet_tissue.make_manifold(verbose=False)
-                            # fix = pymeshfix.MeshFix(tissue_domain)
-                            # fix.repair(verbose=True)
-                            grid, nodes, elems = tetrahedralize(tissue_domain, switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
+                        if uses_spline_constraints:
+                            constraint_data = self._collect_tissue_spline_constraints(
+                                tree=tree,
+                                tissue_constraint_points=tissue_constraint_points,
+                                tissue_constraint_lines=tissue_constraint_lines,
+                                tissue_constraint_spline_sample_points=tissue_constraint_spline_sample_points,
+                                tissue_constraint_tolerance=tissue_constraint_tolerance,
+                            )
+                            grid, nodes, elems, constraint_meta = self._build_constrained_tissue_volume_mesh(
+                                tissue_domain,
+                                constraint_data=constraint_data,
+                                minratio=minratio,
+                                mindihedral=mindihedral,
+                                order=order,
+                                tissue_constraint_tolerance=tissue_constraint_tolerance,
+                                tetgen_exe=tetgen_exe,
+                            )
                             tissue_volume_mesh = grid
-                        except:
+                        else:
                             try:
-                                # tet_tissue.make_manifold(verbose=True)
-                                fix = pymeshfix.MeshFix(fix.mesh)
-                                fix.repair()
-                                grid, nodes, elems = tetrahedralize(fix.mesh, switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
+                                # tet_tissue.make_manifold(verbose=False)
+                                # fix = pymeshfix.MeshFix(tissue_domain)
+                                # fix.repair(verbose=True)
+                                grid, nodes, elems = tetrahedralize(tissue_domain, switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
                                 tissue_volume_mesh = grid
                             except:
-                                tissue_volume_mesh = None
+                                try:
+                                    # tet_tissue.make_manifold(verbose=True)
+                                    fix = pymeshfix.MeshFix(tissue_domain)
+                                    fix.repair()
+                                    grid, nodes, elems = tetrahedralize(fix.mesh, switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
+                                    tissue_volume_mesh = grid
+                                except:
+                                    tissue_volume_mesh = None
                         if isinstance(tissue_volume_mesh, type(None)):
                             print("Failed to generate tissue volume mesh.")
                             network_tissue_surface_meshes.append(None)
                             network_tissue_volume_meshes.append(None)
+                            self.tissue_constraint_metadata.append(None)
                         else:
                             if remesh_vol:
                                 tissue_volume_mesh = remesh_volume(tissue_volume_mesh, hausd=hausd)
                             tissue_domain = tissue_volume_mesh.extract_surface()
                             network_tissue_surface_meshes.append(tissue_domain)
                             network_tissue_volume_meshes.append(tissue_volume_mesh)
+                            self.tissue_constraint_metadata.append(constraint_meta)
                 self.fluid_domain_surface_meshes.append(network_fluid_surface_meshes)
                 self.fluid_domain_volume_meshes.append(network_fluid_volume_meshes)
                 self.tissue_domain_surface_meshes.append(network_tissue_surface_meshes)
                 self.tissue_domain_volume_meshes.append(network_tissue_volume_meshes)
         elif isinstance(self.synthetic_object, svv.forest.forest.Forest) and not isinstance(self.synthetic_object.connections, type(None)):
-            if fluid or tissue:
-                if tissue:
+            if fluid or (tissue and not uses_spline_constraints):
+                if tissue and not uses_spline_constraints:
                     network_solids, _, _ = self.synthetic_object.connections.export_solid(extrude_roots=True)
                 else:
                     network_solids, _, _ = self.synthetic_object.connections.export_solid(extrude_roots=False)
@@ -415,43 +593,67 @@ class Simulation(object):
             if tissue:
                 tissue_domain = deepcopy(self.synthetic_object.domain.boundary)
                 tissue_domain = tissue_domain.compute_normals(auto_orient_normals=True)
-                fluid_hsize = min([mesh.cell_data["hsize"][0] for mesh in self.fluid_domain_surface_meshes])
                 radii = []
                 for net in range(len(self.synthetic_object.networks)):
                     for tr in range(len(self.synthetic_object.networks[net])):
                         radii.append(self.synthetic_object.networks[net][tr].data[0, 21])
                 hsize = min(radii) * 2.0
                 print("Remeshing tissue domain with edge size {}.".format(hsize))
-                tissue_domain = remesh_surface(tissue_domain, hsiz=hsize, verbosity=0)
-                for i, fluid_surface in enumerate(self.fluid_domain_surface_meshes):
-                    fluid_surface_normals = fluid_surface.compute_normals(auto_orient_normals=True)
-                    print("Performing boolean operation with fluid surface mesh {}.".format(i))
-                    tissue_domain = boolean(tissue_domain, fluid_surface_normals, operation='difference', engine='blender')
-                    tissue_domain = tissue_domain.compute_normals(auto_orient_normals=True)
-                    print("Remeshing tissue domain with edge size {}.".format(fluid_hsize))
-                    #tissue_domain = remesh_surface(tissue_domain, hmin=fluid_hsize, hmax=hsize)
-                    tissue_domain = remesh_surface(tissue_domain, optim=True)
+                if uses_spline_constraints:
+                    tissue_domain = self._prepare_constrained_tissue_boundary(tissue_domain, hsiz=hsize)
+                else:
+                    fluid_hsize = min([mesh.cell_data["hsize"][0] for mesh in self.fluid_domain_surface_meshes])
+                    tissue_domain = self._remesh_tissue_boundary(tissue_domain, hsiz=hsize)
+                    for i, fluid_surface in enumerate(self.fluid_domain_surface_meshes):
+                        fluid_surface_normals = fluid_surface.compute_normals(auto_orient_normals=True)
+                        print("Performing boolean operation with fluid surface mesh {}.".format(i))
+                        tissue_domain = boolean(tissue_domain, fluid_surface_normals, operation='difference', engine='blender')
+                        tissue_domain = tissue_domain.compute_normals(auto_orient_normals=True)
+                        print("Remeshing tissue domain with edge size {}.".format(fluid_hsize))
+                        #tissue_domain = remesh_surface(tissue_domain, hmin=fluid_hsize, hmax=hsize)
+                        tissue_domain = self._remesh_tissue_boundary(tissue_domain, optim=True)
                 self.tissue_domain_surface_meshes.append(tissue_domain)
                 #tissue_domain = remesh_surface(tissue_domain, hausd=hausd)
                 print("Tetrahedralizing tissue domain.")
                 #tet_tissue = tetgen.TetGen(tissue_domain)
-                try:
-                    grid, nodes, elems = tetrahedralize(tissue_domain, switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
+                if uses_spline_constraints:
+                    constraint_data = self._collect_tissue_spline_constraints(
+                        tissue_constraint_points=tissue_constraint_points,
+                        tissue_constraint_lines=tissue_constraint_lines,
+                        tissue_constraint_spline_sample_points=tissue_constraint_spline_sample_points,
+                        tissue_constraint_tolerance=tissue_constraint_tolerance,
+                    )
+                    grid, nodes, elems, constraint_meta = self._build_constrained_tissue_volume_mesh(
+                        tissue_domain,
+                        constraint_data=constraint_data,
+                        minratio=minratio,
+                        mindihedral=mindihedral,
+                        order=order,
+                        tissue_constraint_tolerance=tissue_constraint_tolerance,
+                        tetgen_exe=tetgen_exe,
+                    )
                     tissue_volume_mesh = grid
-                except:
-                    #tet_tissue.make_manifold(verbose=True)
-                    fix = pymeshfix.MeshFix(tissue_domain)
-                    fix.repair()
-                    grid, nodes, elems = tetrahedralize(fix.mesh, switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
-                    tissue_volume_mesh = grid
+                else:
+                    constraint_meta = None
+                    try:
+                        grid, nodes, elems = tetrahedralize(tissue_domain, switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
+                        tissue_volume_mesh = grid
+                    except:
+                        #tet_tissue.make_manifold(verbose=True)
+                        fix = pymeshfix.MeshFix(tissue_domain)
+                        fix.repair()
+                        grid, nodes, elems = tetrahedralize(fix.mesh, switches='pq{}/{}MVYSJ'.format(minratio, mindihedral))
+                        tissue_volume_mesh = grid
                 if isinstance(tissue_volume_mesh, type(None)):
                     print("Failed to generate tissue volume mesh.")
+                    self.tissue_constraint_metadata.append(None)
                 else:
                     if remesh_vol:
                         tissue_volume_mesh = remesh_volume(tissue_volume_mesh, hausd=hausd, nosurf=True)
                     tissue_surface = tissue_volume_mesh.extract_surface()
                     self.tissue_domain_surface_meshes[-1] = tissue_surface
                     self.tissue_domain_volume_meshes.append(tissue_volume_mesh)
+                    self.tissue_constraint_metadata.append(constraint_meta)
         else:
             raise ValueError("Unsupported synthetic object type.")
 

--- a/svv/simulation/utils/spline_constraints.py
+++ b/svv/simulation/utils/spline_constraints.py
@@ -1,0 +1,143 @@
+import numpy as np
+
+
+def _append_splines(container, item):
+    if item is None:
+        return
+    if callable(item):
+        container.append(item)
+        return
+    if isinstance(item, (list, tuple)):
+        for child in item:
+            _append_splines(container, child)
+        return
+    raise TypeError(f"Unsupported spline container element: {type(item)!r}")
+
+
+def flatten_spline_functions(splines):
+    """Return a flat list of callable spline evaluators."""
+    flat = []
+    _append_splines(flat, splines)
+    return flat
+
+
+def sample_spline_functions(splines, spline_sample_points=100):
+    """Sample spline callables into point and line constraints."""
+    if spline_sample_points < 2:
+        raise ValueError("spline_sample_points must be at least 2.")
+
+    flat_splines = flatten_spline_functions(splines)
+    if not flat_splines:
+        return {
+            "points": np.empty((0, 3), dtype=float),
+            "lines": np.empty((0, 2), dtype=np.int64),
+            "spline_id": np.empty((0,), dtype=np.int32),
+            "spline_order": np.empty((0,), dtype=np.int32),
+            "radius": np.empty((0,), dtype=float),
+        }
+
+    all_points = []
+    all_lines = []
+    all_spline_ids = []
+    all_spline_orders = []
+    all_radii = []
+    point_offset = 0
+
+    for spline_id, spline in enumerate(flat_splines):
+        t = np.linspace(0.0, 1.0, num=spline_sample_points)
+        data = spline(t)
+        coords = np.column_stack(
+            (
+                np.asarray(data[0], dtype=float),
+                np.asarray(data[1], dtype=float),
+                np.asarray(data[2], dtype=float),
+            )
+        )
+        radii = np.asarray(data[3], dtype=float).reshape(-1)
+        if coords.shape[0] != radii.shape[0]:
+            raise ValueError("Spline evaluation returned inconsistent point and radius counts.")
+        if coords.shape[0] < 2:
+            raise ValueError("Each spline must yield at least two sample points.")
+
+        all_points.append(coords)
+        all_radii.append(radii)
+        all_spline_ids.append(np.full(coords.shape[0], spline_id, dtype=np.int32))
+        all_spline_orders.append(np.arange(coords.shape[0], dtype=np.int32))
+        all_lines.append(
+            np.column_stack(
+                (
+                    np.arange(point_offset, point_offset + coords.shape[0] - 1, dtype=np.int64),
+                    np.arange(point_offset + 1, point_offset + coords.shape[0], dtype=np.int64),
+                )
+            )
+        )
+        point_offset += coords.shape[0]
+
+    return {
+        "points": np.vstack(all_points),
+        "lines": np.vstack(all_lines),
+        "spline_id": np.concatenate(all_spline_ids),
+        "spline_order": np.concatenate(all_spline_orders),
+        "radius": np.concatenate(all_radii),
+    }
+
+
+def deduplicate_spline_constraints(points, lines=None, spline_id=None, spline_order=None, radius=None, tol=1e-8):
+    """Deduplicate sampled spline points and remap line connectivity."""
+    points = np.asarray(points, dtype=float).reshape(-1, 3)
+    lines = np.empty((0, 2), dtype=np.int64) if lines is None else np.asarray(lines, dtype=np.int64).reshape(-1, 2)
+    spline_id = np.full(points.shape[0], -1, dtype=np.int32) if spline_id is None else np.asarray(spline_id, dtype=np.int32).reshape(-1)
+    spline_order = np.full(points.shape[0], -1, dtype=np.int32) if spline_order is None else np.asarray(spline_order, dtype=np.int32).reshape(-1)
+    radius = np.full(points.shape[0], np.nan, dtype=float) if radius is None else np.asarray(radius, dtype=float).reshape(-1)
+
+    if points.shape[0] == 0:
+        return {
+            "points": points,
+            "lines": lines,
+            "spline_id": spline_id,
+            "spline_order": spline_order,
+            "radius": radius,
+        }
+
+    old_to_new = np.empty(points.shape[0], dtype=np.int64)
+    key_to_new = {}
+    unique_points = []
+    unique_spline_id = []
+    unique_spline_order = []
+    unique_radius = []
+
+    for idx, point in enumerate(points):
+        if tol > 0.0:
+            key = tuple(np.round(point / tol).astype(np.int64).tolist())
+        else:
+            key = tuple(point.tolist())
+        mapped = key_to_new.get(key)
+        if mapped is None:
+            mapped = len(unique_points)
+            key_to_new[key] = mapped
+            unique_points.append(point)
+            unique_spline_id.append(int(spline_id[idx]))
+            unique_spline_order.append(int(spline_order[idx]))
+            unique_radius.append(float(radius[idx]))
+        old_to_new[idx] = mapped
+
+    remapped_lines = []
+    seen = set()
+    for line in lines:
+        start = int(old_to_new[int(line[0])])
+        end = int(old_to_new[int(line[1])])
+        if start == end:
+            continue
+        key = (start, end)
+        if key in seen:
+            continue
+        seen.add(key)
+        remapped_lines.append([start, end])
+
+    return {
+        "points": np.asarray(unique_points, dtype=float),
+        "lines": np.asarray(remapped_lines, dtype=np.int64).reshape(-1, 2),
+        "spline_id": np.asarray(unique_spline_id, dtype=np.int32),
+        "spline_order": np.asarray(unique_spline_order, dtype=np.int32),
+        "radius": np.asarray(unique_radius, dtype=float),
+    }

--- a/svv/tree/export/write_splines.py
+++ b/svv/tree/export/write_splines.py
@@ -3,6 +3,7 @@ import numpy as np
 import numpy
 from copy import deepcopy
 import os
+from pathlib import Path
 
 def get_longest_path(data, seed_edge):
     dig = True
@@ -246,10 +247,13 @@ def get_interpolated_sv_data(data):
             #interp_n.append(splprep(n, s=0))
     return interp_xyz, interp_r, interp_n, path_frames, branches, interp_xyzr
 
-def write_splines(interp_xyzr, spline_sample_points=100, write_splines=True):
+def write_splines(interp_xyzr, spline_sample_points=100, write_splines=True, outdir=None):
     tree_splines = []
     if write_splines:
-        spline_file = open(os.getcwd() + os.sep + "tree_b_splines.txt", "w+")
+        target_dir = Path(outdir) if outdir is not None else Path(os.getcwd())
+        target_dir.mkdir(parents=True, exist_ok=True)
+        spline_path = target_dir / "tree_b_splines.txt"
+        spline_file = open(spline_path, "w+", encoding="utf-8")
     for vessel in range(len(interp_xyzr)):
         def vessel_spline(t, ctr=interp_xyzr[vessel]):
             return splev(t, ctr[0])

--- a/svv/tree/tree.py
+++ b/svv/tree/tree.py
@@ -15,7 +15,7 @@ from svv.visualize.tree.show import show
 from svv.tree.branch.bifurcation import add_vessel, check_tree
 from svv.tree.export.export_solid import build_watertight_solid, build_merged_solid
 from svv.tree.export.export_centerlines import build_centerlines
-from svv.tree.export.write_splines import get_interpolated_sv_data, write_splines
+from svv.tree.export.write_splines import get_interpolated_sv_data, write_splines as write_tree_splines
 from svv.tree.utils.TreeManager import KDTreeManager, USearchTree
 from svv.tree.utils.c_extend import build_c_vessel_map
 from collections import ChainMap
@@ -597,7 +597,12 @@ class Tree(object):
     def export_gcode(self):
         pass
 
-    def export_splines(self, spline_sample_points=100):
+    def export_splines(self, spline_sample_points=100, write_splines=True, outdir=None):
         interp_xyz, interp_r, interp_n, path_frames, branches, interp_xyzr = get_interpolated_sv_data(self.data)
-        splines = write_splines(interp_xyzr, spline_sample_points=spline_sample_points)
+        splines = write_tree_splines(
+            interp_xyzr,
+            spline_sample_points=spline_sample_points,
+            write_splines=write_splines,
+            outdir=outdir,
+        )
         return splines

--- a/svv/utils/meshing/__init__.py
+++ b/svv/utils/meshing/__init__.py
@@ -1,0 +1,8 @@
+from .tetgen import get_packaged_tetgen_cli_path, tetgen_arch_dir, tetgen_executable_name, tetgen_os_dir
+
+__all__ = [
+    "get_packaged_tetgen_cli_path",
+    "tetgen_arch_dir",
+    "tetgen_executable_name",
+    "tetgen_os_dir",
+]

--- a/svv/utils/meshing/tetgen.py
+++ b/svv/utils/meshing/tetgen.py
@@ -1,0 +1,58 @@
+import os
+import platform
+from pathlib import Path
+
+
+def tetgen_os_dir():
+    sysname = platform.system()
+    if sysname == "Linux":
+        return "Linux"
+    if sysname == "Windows":
+        return "Windows"
+    if sysname == "Darwin":
+        return "Mac"
+    raise RuntimeError(f"Unsupported OS for TetGen CLI packaging: {sysname}")
+
+
+def tetgen_executable_name(os_dir=None):
+    if os_dir is None:
+        os_dir = tetgen_os_dir()
+    return "tetgen.exe" if os_dir == "Windows" else "tetgen"
+
+
+def tetgen_arch_dir(os_dir=None, base_dir=None):
+    if os_dir is None:
+        os_dir = tetgen_os_dir()
+
+    override = os.environ.get("SVV_TETGEN_ARCH", "").strip()
+    if override:
+        ov = override.lower()
+        if ov in {"x86_64", "amd64"}:
+            return "x86_64"
+        if ov in {"aarch64", "arm64"}:
+            return "aarch64"
+        if ov == "universal2":
+            return "universal2"
+        return override
+
+    base = Path(base_dir) if base_dir is not None else Path(__file__).resolve().parent
+    if os_dir == "Mac":
+        exe_name = tetgen_executable_name(os_dir)
+        if (base / "Mac" / "universal2" / exe_name).is_file():
+            return "universal2"
+
+    machine = platform.machine().strip().lower()
+    if machine in {"x86_64", "amd64"}:
+        return "x86_64"
+    if machine in {"aarch64", "arm64"}:
+        return "aarch64"
+    return machine or "unknown"
+
+
+def get_packaged_tetgen_cli_path(base_dir=None):
+    base = Path(base_dir) if base_dir is not None else Path(__file__).resolve().parent
+    os_dir = tetgen_os_dir()
+    arch_dir = tetgen_arch_dir(os_dir=os_dir, base_dir=base)
+    exe_name = tetgen_executable_name(os_dir)
+    candidate = base / os_dir / arch_dir / exe_name
+    return str(candidate) if candidate.is_file() else None

--- a/svv/visualize/gui/main_window.py
+++ b/svv/visualize/gui/main_window.py
@@ -465,6 +465,8 @@ class VascularizeGUI(QMainWindow):
         self._zerod_progress_dialog: Optional[QProgressDialog] = None
         self._zerod_stdout_buffer = ""
         self._zerod_stderr_buffer = ""
+        self._constrained_tissue_preview_actors = []
+        self._last_constrained_tissue_simulation = None
 
         # Persistent layout
         self.settings = QSettings("SimVascular", "svVascularize")
@@ -879,6 +881,13 @@ class VascularizeGUI(QMainWindow):
         export_3d_action.setStatusTip("Build meshes and export 3D simulation setup for the current tree or forest")
         export_3d_action.triggered.connect(self.export_3d_simulation_dialog)
         simulate_menu.addAction(export_3d_action)
+
+        self.build_constrained_tissue_mesh_action = QAction("Build Constrained Tissue Mesh...", self)
+        self.build_constrained_tissue_mesh_action.setStatusTip(
+            "Build a spline-constrained tissue mesh and preview the tissue surface in the viewport"
+        )
+        self.build_constrained_tissue_mesh_action.triggered.connect(self.build_constrained_tissue_mesh_dialog)
+        simulate_menu.addAction(self.build_constrained_tissue_mesh_action)
 
         inspect_solution_action = QAction("Inspect Solutions...", self)
         inspect_solution_action.setStatusTip("Inspect time-varying simulation solutions in a dedicated viewport")
@@ -1299,6 +1308,153 @@ class VascularizeGUI(QMainWindow):
                 action="require_synthetic_object",
             )
         return obj
+
+    @staticmethod
+    def _iter_nested_meshes(meshes):
+        if meshes is None:
+            return
+        if isinstance(meshes, (list, tuple)):
+            for item in meshes:
+                yield from VascularizeGUI._iter_nested_meshes(item)
+            return
+        yield meshes
+
+    def _clear_constrained_tissue_mesh_preview(self):
+        if not self._constrained_tissue_preview_actors:
+            return
+        plotter = getattr(self.vtk_widget, "plotter", None)
+        if plotter is not None:
+            for actor in self._constrained_tissue_preview_actors:
+                try:
+                    plotter.remove_actor(actor)
+                except Exception:
+                    pass
+        self._constrained_tissue_preview_actors = []
+
+    def _show_constrained_tissue_mesh_preview(self, surfaces):
+        plotter = getattr(self.vtk_widget, "plotter", None)
+        if plotter is None:
+            return
+
+        self._clear_constrained_tissue_mesh_preview()
+        surface_color = CADTheme.get_color('viewport', 'domain-surface')
+        edge_color = CADTheme.get_color('viewport', 'domain-edge')
+        for idx, surface in enumerate(surfaces):
+            actor = plotter.add_mesh(
+                surface,
+                color=surface_color,
+                opacity=0.55,
+                show_edges=True,
+                edge_color=edge_color,
+                line_width=1,
+                specular=0.15,
+                smooth_shading=True,
+                name=f"constrained_tissue_mesh_{idx}",
+            )
+            self._constrained_tissue_preview_actors.append(actor)
+        self.vtk_widget.request_render()
+
+    def _build_constrained_tissue_mesh(self, obj, *, spline_sample_points: int, tolerance: float,
+                                       show_overlay: bool = True):
+        from svv.simulation.simulation import Simulation
+
+        sim = Simulation(obj)
+        sim.build_meshes(
+            fluid=False,
+            tissue=True,
+            tissue_mesh_type="spline_point_constrained",
+            tissue_constraint_spline_sample_points=int(spline_sample_points),
+            tissue_constraint_tolerance=float(tolerance),
+        )
+
+        volume_meshes = [
+            mesh for mesh in self._iter_nested_meshes(sim.tissue_domain_volume_meshes)
+            if mesh is not None
+        ]
+        if not volume_meshes:
+            raise RuntimeError("No constrained tissue volume mesh was produced.")
+
+        surfaces = []
+        for mesh in volume_meshes:
+            surface = mesh.extract_surface()
+            if surface is not None and getattr(surface, "n_points", 0) > 0:
+                surfaces.append(surface)
+
+        if show_overlay and surfaces:
+            self._show_constrained_tissue_mesh_preview(surfaces)
+
+        self._last_constrained_tissue_simulation = sim
+        return sim, volume_meshes, surfaces
+
+    def build_constrained_tissue_mesh_dialog(self):
+        obj = self._require_synthetic_object()
+        if obj is None:
+            return
+        if getattr(getattr(obj, "domain", None), "boundary", None) is None:
+            QMessageBox.warning(
+                self,
+                "Missing Domain",
+                "The current Tree or Forest does not have a domain boundary."
+            )
+            return
+
+        dlg = QDialog(self)
+        dlg.setWindowTitle("Build Constrained Tissue Mesh")
+        form = QFormLayout(dlg)
+
+        sample_spin = QSpinBox()
+        sample_spin.setRange(2, 10000)
+        sample_spin.setValue(100)
+        sample_spin.setToolTip("Number of sampled spline points per vessel used as constrained nodes.")
+        form.addRow("Sample points per vessel:", sample_spin)
+
+        tolerance_spin = QDoubleSpinBox()
+        tolerance_spin.setDecimals(8)
+        tolerance_spin.setRange(1e-8, 1.0)
+        tolerance_spin.setSingleStep(1e-6)
+        tolerance_spin.setValue(1e-6)
+        tolerance_spin.setToolTip("Exact node-match tolerance used after constrained tetrahedralization.")
+        form.addRow("Node-match tolerance:", tolerance_spin)
+
+        overlay_cb = QCheckBox("Show tissue mesh overlay in viewport")
+        overlay_cb.setChecked(True)
+        form.addRow("", overlay_cb)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(dlg.accept)
+        buttons.rejected.connect(dlg.reject)
+        form.addRow(buttons)
+
+        if dlg.exec() != QDialog.Accepted:
+            return
+
+        try:
+            self.show_progress("Building constrained tissue mesh...")
+            QApplication.processEvents()
+            sim, volume_meshes, _ = self._build_constrained_tissue_mesh(
+                obj,
+                spline_sample_points=sample_spin.value(),
+                tolerance=float(tolerance_spin.value()),
+                show_overlay=overlay_cb.isChecked(),
+            )
+            total_cells = sum(int(getattr(mesh, "n_cells", 0)) for mesh in volume_meshes)
+            meta = getattr(sim, "tissue_constraint_metadata", None) or []
+            self.log_output(
+                f"[3D] built constrained tissue mesh with {len(volume_meshes)} volume mesh(es), "
+                f"{total_cells} cells, sample points per vessel={sample_spin.value()}, "
+                f"constraint metadata={meta}"
+            )
+            self.update_status("Constrained tissue mesh built")
+        except Exception as e:
+            self._record_telemetry(e, action="build_constrained_tissue_mesh")
+            self.update_status("Constrained tissue mesh build failed")
+            QMessageBox.critical(
+                self,
+                "Build Constrained Tissue Mesh Failed",
+                f"Failed to build the constrained tissue mesh:\n\n{e}"
+            )
+        finally:
+            self.hide_progress()
 
     def export_centerlines_dialog(self):
         """Export centerline spline data for the current Tree/Forest."""
@@ -2948,7 +3104,12 @@ class VascularizeGUI(QMainWindow):
             if cancel_event.is_set():
                 return None
 
-            if domain.boundary is None and hasattr(domain, 'patches') and len(domain.patches) > 0:
+            if (
+                getattr(domain, 'boundary', None) is None
+                and not getattr(domain, '_build_failed', False)
+                and hasattr(domain, 'patches')
+                and len(domain.patches) > 0
+            ):
                 report_progress(92, "Building boundary from patches...")
                 domain.build(progress_callback=make_stage_reporter(92, 98))
                 report_progress(98, "Boundary built")
@@ -3005,7 +3166,9 @@ class VascularizeGUI(QMainWindow):
                     f"<i>Loading {suffix} file will run:<br>"
                     f"• create() - Initialize implicit function<br>"
                     f"• solve() - Compute evaluation structures<br>"
-                    f"• build() - Tetrahedralize and extract boundary</i>"
+                    f"• build() - Tetrahedralize and extract boundary<br><br>"
+                    f"Large mesh files can take a while here.<br>"
+                    f"For faster future reloads, save the result as a .dmn file and include the full mesh.</i>"
                 )
                 info_label.setWordWrap(True)
                 form.addRow(info_label)

--- a/test/test_simulation_spline_constrained_mesh.py
+++ b/test/test_simulation_spline_constrained_mesh.py
@@ -1,0 +1,234 @@
+import sys
+import types
+
+import pytest
+
+class _MeshFixStub:
+    def __init__(self, mesh, *args, **kwargs):
+        self.mesh = mesh
+
+    def repair(self, *args, **kwargs):
+        return self.mesh
+
+
+class _TetGenStub:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+sys.modules.setdefault("pymeshfix", types.SimpleNamespace(MeshFix=_MeshFixStub))
+sys.modules.setdefault("tetgen", types.SimpleNamespace(TetGen=_TetGenStub))
+sys.modules.setdefault("meshio", types.SimpleNamespace())
+sys.modules.setdefault("trimesh", types.SimpleNamespace(Trimesh=object))
+
+import numpy as np
+import pyvista as pv
+
+from svv.simulation.simulation import Simulation
+from svv.tree.data.data import TreeData
+from svv.tree.tree import Tree
+
+
+class _StaticDomain:
+    def __init__(self, boundary):
+        self.boundary = boundary
+
+
+
+def _make_tree():
+    tree = Tree()
+    data = TreeData((2, 31))
+    data[:] = np.nan
+
+    data[0, 0:3] = [0.0, 0.0, 0.0]
+    data[0, 3:6] = [1.0, 0.0, 0.0]
+    data[1, 0:3] = [1.0, 0.0, 0.0]
+    data[1, 3:6] = [2.0, 0.0, 0.0]
+    data[:, 12:15] = [1.0, 0.0, 0.0]
+    data[:, 20] = 1.0
+    data[:, 21] = 0.1
+    data[:, 22] = 0.05
+    data[0, 15] = 1
+    data[1, 17] = 0
+    data[0, 26] = 0
+    data[1, 26] = 1
+
+    tree.data = data
+    boundary = pv.Sphere(radius=3.0, theta_resolution=12, phi_resolution=12).triangulate()
+    tree.domain = _StaticDomain(boundary)
+
+    solid = pv.Sphere(radius=0.2, center=(0.5, 0.0, 0.0), theta_resolution=12, phi_resolution=12).triangulate()
+    solid.cell_data["hsize"] = np.full(solid.n_cells, 0.1)
+    tree.export_solid = lambda watertight=True, _solid=solid: _solid.copy(deep=True)
+    return tree
+
+
+
+def _make_fake_grid():
+    points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=float,
+    )
+    cells = np.array([4, 0, 1, 2, 3], dtype=np.int64)
+    celltypes = np.array([pv.CellType.TETRA], dtype=np.uint8)
+    return pv.UnstructuredGrid(cells, celltypes, points)
+
+
+
+def test_build_meshes_spline_point_constrained_uses_tree_splines(monkeypatch):
+    import svv.simulation.simulation as sim_mod
+
+    tree = _make_tree()
+    sim = Simulation(tree)
+    captured = {}
+
+    monkeypatch.setattr(sim_mod, "remesh_surface", lambda mesh, **kwargs: mesh)
+    monkeypatch.setattr(sim_mod, "boolean", lambda a, b, **kwargs: a)
+
+    def fake_build(self, tissue_domain, *, constraint_data, **kwargs):
+        captured["constraint_data"] = constraint_data
+        grid = _make_fake_grid()
+        elems = np.array([[0, 1, 2, 3]], dtype=np.int64)
+        return grid, grid.points.copy(), elems, {"source": "fake", "point_count": constraint_data["points"].shape[0]}
+
+    monkeypatch.setattr(Simulation, "_build_constrained_tissue_volume_mesh", fake_build)
+
+    sim.build_meshes(
+        fluid=False,
+        tissue=True,
+        tissue_mesh_type="spline_point_constrained",
+        tissue_constraint_spline_sample_points=8,
+    )
+
+    assert "constraint_data" in captured
+    constraint_data = captured["constraint_data"]
+    assert constraint_data["points"].shape[0] > 0
+    assert constraint_data["lines"].shape[0] > 0
+    assert np.isfinite(constraint_data["radius"]).all()
+    assert constraint_data["points"][:, 0].min() >= 0.0
+    assert constraint_data["points"][:, 0].max() <= 2.0
+    assert sim.tissue_constraint_metadata == [{"source": "fake", "point_count": constraint_data["points"].shape[0]}]
+    assert len(sim.tissue_domain_volume_meshes) == 1
+    assert sim.tissue_domain_volume_meshes[0].n_cells == 1
+
+
+
+def test_build_meshes_spline_point_constrained_skips_boolean_tree_tissue(monkeypatch):
+    import svv.simulation.simulation as sim_mod
+
+    tree = _make_tree()
+    tree.export_solid = lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("export_solid should not be called"))
+    sim = Simulation(tree)
+    captured = {}
+
+    monkeypatch.setattr(
+        sim_mod,
+        "remesh_surface",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("remesh_surface should not be called")),
+    )
+    monkeypatch.setattr(
+        sim_mod,
+        "boolean",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("boolean should not be called")),
+    )
+
+    def fake_build(self, tissue_domain, *, constraint_data, **kwargs):
+        captured["tissue_domain"] = tissue_domain.copy(deep=True)
+        grid = _make_fake_grid()
+        elems = np.array([[0, 1, 2, 3]], dtype=np.int64)
+        return grid, grid.points.copy(), elems, {"source": "fake", "point_count": constraint_data["points"].shape[0]}
+
+    monkeypatch.setattr(Simulation, "_build_constrained_tissue_volume_mesh", fake_build)
+
+    sim.build_meshes(
+        fluid=False,
+        tissue=True,
+        tissue_mesh_type="spline_point_constrained",
+        tissue_constraint_spline_sample_points=8,
+    )
+
+    assert np.allclose(captured["tissue_domain"].points, tree.domain.boundary.points)
+    assert sim.fluid_domain_surface_meshes == []
+    assert sim.fluid_domain_volume_meshes == []
+    assert len(sim.tissue_domain_volume_meshes) == 1
+
+
+
+def test_build_constrained_tissue_volume_mesh_does_not_meshfix_manifold_surface(monkeypatch):
+    import svv.simulation.simulation as sim_mod
+
+    tree = _make_tree()
+    sim = Simulation(tree)
+    constraint_data = {
+        "points": np.array([[0.0, 0.0, 0.0]], dtype=float),
+        "lines": np.empty((0, 2), dtype=np.int64),
+        "spline_id": np.array([0], dtype=np.int32),
+        "spline_order": np.array([0], dtype=np.int32),
+        "radius": np.array([0.1], dtype=float),
+    }
+
+    monkeypatch.setattr(
+        sim_mod,
+        "tetrahedralize_with_prescribed_points",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    monkeypatch.setattr(
+        sim_mod.pymeshfix,
+        "MeshFix",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("MeshFix should not be called")),
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        sim._build_constrained_tissue_volume_mesh(
+            tree.domain.boundary,
+            constraint_data=constraint_data,
+        )
+
+
+
+def test_build_meshes_spline_point_constrained_with_fluid_skips_boolean_and_root_extension(monkeypatch):
+    import svv.simulation.simulation as sim_mod
+
+    tree = _make_tree()
+    sim = Simulation(tree)
+    captured = {}
+    original_root = tree.data[0, 0:3].copy()
+
+    monkeypatch.setattr(sim_mod, "remesh_surface", lambda mesh, **kwargs: mesh)
+    monkeypatch.setattr(
+        sim_mod,
+        "boolean",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("boolean should not be called")),
+    )
+
+    def fake_tetrahedralize(mesh, switches=None):
+        grid = _make_fake_grid()
+        elems = np.array([[0, 1, 2, 3]], dtype=np.int64)
+        return grid, grid.points.copy(), elems
+
+    def fake_build(self, tissue_domain, *, constraint_data, **kwargs):
+        captured["tissue_domain"] = tissue_domain.copy(deep=True)
+        grid = _make_fake_grid()
+        elems = np.array([[0, 1, 2, 3]], dtype=np.int64)
+        return grid, grid.points.copy(), elems, {"source": "fake", "point_count": constraint_data["points"].shape[0]}
+
+    monkeypatch.setattr(sim_mod, "tetrahedralize", fake_tetrahedralize)
+    monkeypatch.setattr(Simulation, "_build_constrained_tissue_volume_mesh", fake_build)
+
+    sim.build_meshes(
+        fluid=True,
+        tissue=True,
+        boundary_layer=False,
+        tissue_mesh_type="spline_point_constrained",
+        tissue_constraint_spline_sample_points=8,
+    )
+
+    assert np.allclose(tree.data[0, 0:3], original_root)
+    assert np.allclose(captured["tissue_domain"].points, tree.domain.boundary.points)
+    assert len(sim.fluid_domain_volume_meshes) == 1
+    assert len(sim.tissue_domain_volume_meshes) == 1

--- a/test/test_spline_export_files.py
+++ b/test/test_spline_export_files.py
@@ -1,9 +1,34 @@
+import sys
+import types
+
+
+class _MeshFixStub:
+    def __init__(self, mesh, *args, **kwargs):
+        self.mesh = mesh
+
+    def repair(self, *args, **kwargs):
+        return self.mesh
+
+
+class _TetGenStub:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+sys.modules.setdefault("pymeshfix", types.SimpleNamespace(MeshFix=_MeshFixStub))
+sys.modules.setdefault("tetgen", types.SimpleNamespace(TetGen=_TetGenStub))
+sys.modules.setdefault("meshio", types.SimpleNamespace())
+sys.modules.setdefault("trimesh", types.SimpleNamespace(Trimesh=object))
+
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
 from svv.forest.export.export_spline import write_splines as write_forest_splines
+from svv.forest.forest import Forest
+from svv.tree.data.data import TreeData
+from svv.tree.tree import Tree
 from svv.visualize.spline_export import export_spline_files
 
 
@@ -319,3 +344,57 @@ def test_forest_spline_writer_returns_all_network_splines_and_files(tmp_path):
         "network_0_b_splines.txt",
         "network_1_b_splines.txt",
     ]
+
+
+
+def _make_tree_object(x_offset: float, y_offset: float = 0.0, radius: float = 0.1):
+    tree = Tree()
+    data = TreeData((2, 31))
+    data[:] = np.nan
+
+    data[0, 0:3] = [x_offset + 0.0, y_offset, 0.0]
+    data[0, 3:6] = [x_offset + 1.0, y_offset, 0.0]
+    data[1, 0:3] = [x_offset + 1.0, y_offset, 0.0]
+    data[1, 3:6] = [x_offset + 2.0, y_offset, 0.0]
+
+    data[:, 12:15] = [1.0, 0.0, 0.0]
+    data[:, 20] = 1.0
+    data[:, 21] = radius
+
+    data[0, 15] = 1
+    data[1, 17] = 0
+    data[0, 26] = 0
+    data[1, 26] = 1
+
+    tree.data = data
+    return tree
+
+
+def test_tree_export_splines_can_return_callables_without_writing(tmp_path, monkeypatch):
+    tree = _make_tree_object(0.0, 0.0)
+    monkeypatch.chdir(tmp_path)
+
+    splines = tree.export_splines(spline_sample_points=7, write_splines=False)
+
+    assert len(splines) == 1
+    assert callable(splines[0])
+    sampled = splines[0](np.linspace(0.0, 1.0, 7))
+    assert len(sampled) == 4
+    assert not (tmp_path / "tree_b_splines.txt").exists()
+
+
+def test_forest_export_splines_can_return_callables_without_writing(tmp_path, monkeypatch):
+    forest = Forest(n_networks=1, n_trees_per_network=[1])
+    tree_connection = _make_connected_tree_connection(network_id=0, x_offset=0.0, y_offset=0.0)
+    forest.connections = SimpleNamespace(tree_connections=[tree_connection])
+    tree_connection.forest = forest
+    monkeypatch.chdir(tmp_path)
+
+    splines = forest.export_splines(spline_sample_points=6, write_splines=False)
+
+    assert len(splines) == 1
+    assert len(splines[0]) == 1
+    assert callable(splines[0][0][0])
+    sampled = splines[0][0][0](np.linspace(0.0, 1.0, 6))
+    assert len(sampled) == 4
+    assert not (tmp_path / "splines_tmp").exists()

--- a/test/test_tetgen_cli_selector.py
+++ b/test/test_tetgen_cli_selector.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from svv.domain.routines import tetgen_constrained as constrained_mod
+from svv.utils.meshing.tetgen import (
+    get_packaged_tetgen_cli_path,
+    tetgen_arch_dir,
+    tetgen_executable_name,
+    tetgen_os_dir,
+)
+
+
+def _write_fake_tetgen(base_dir):
+    os_dir = tetgen_os_dir()
+    arch_dir = tetgen_arch_dir(os_dir=os_dir, base_dir=base_dir)
+    exe_name = tetgen_executable_name(os_dir)
+    exe_path = Path(base_dir) / os_dir / arch_dir / exe_name
+    exe_path.parent.mkdir(parents=True, exist_ok=True)
+    exe_path.write_text('', encoding='utf-8')
+    return exe_path
+
+
+def test_get_packaged_tetgen_cli_path_finds_staged_binary(tmp_path):
+    exe_path = _write_fake_tetgen(tmp_path)
+    assert get_packaged_tetgen_cli_path(base_dir=tmp_path) == str(exe_path)
+
+
+def test_resolve_tetgen_exe_prefers_explicit_path(monkeypatch, tmp_path):
+    explicit = tmp_path / 'tetgen-explicit'
+    explicit.write_text('', encoding='utf-8')
+    monkeypatch.setattr(constrained_mod, 'get_packaged_tetgen_cli_path', lambda: None)
+    monkeypatch.setattr(constrained_mod.shutil, 'which', lambda name: '/usr/bin/tetgen')
+    monkeypatch.delenv('SVV_TETGEN_PATH', raising=False)
+
+    assert constrained_mod.resolve_tetgen_exe(str(explicit)) == str(explicit)
+
+
+def test_resolve_tetgen_exe_prefers_env_then_packaged_then_path(monkeypatch, tmp_path):
+    packaged = _write_fake_tetgen(tmp_path)
+    env_exe = tmp_path / 'tetgen-env'
+    env_exe.write_text('', encoding='utf-8')
+    monkeypatch.setattr(constrained_mod, 'get_packaged_tetgen_cli_path', lambda: str(packaged))
+    monkeypatch.setattr(constrained_mod.shutil, 'which', lambda name: '/usr/bin/tetgen')
+
+    monkeypatch.setenv('SVV_TETGEN_PATH', str(env_exe))
+    assert constrained_mod.resolve_tetgen_exe(None) == str(env_exe)
+
+    monkeypatch.delenv('SVV_TETGEN_PATH', raising=False)
+    assert constrained_mod.resolve_tetgen_exe(None) == str(packaged)

--- a/test/test_tetgen_constrained.py
+++ b/test/test_tetgen_constrained.py
@@ -1,0 +1,143 @@
+import numpy as np
+import pyvista as pv
+import pytest
+
+from svv.domain.routines import tetgen_constrained as constrained_mod
+
+
+def _surface():
+    return pv.Sphere(radius=1.0, theta_resolution=24, phi_resolution=24).triangulate()
+
+
+def test_filter_prescribed_points_to_surface_drops_outside_points_and_remaps_lines():
+    surface = _surface()
+    points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.0, 0.0],
+            [1.5, 0.0, 0.0],
+            [0.0, 0.0, 1.25],
+        ],
+        dtype=float,
+    )
+    lines = np.array([[0, 1], [1, 2], [2, 3]], dtype=np.int64)
+    point_metadata = {
+        "spline_id": np.array([4, 4, 4, 9], dtype=np.int32),
+        "spline_order": np.array([0, 1, 2, 0], dtype=np.int32),
+        "radius": np.array([0.1, 0.2, 0.3, 0.4], dtype=float),
+    }
+
+    filtered = constrained_mod.filter_prescribed_points_to_surface(
+        surface,
+        points,
+        lines,
+        point_metadata=point_metadata,
+        verify_tol=1e-6,
+    )
+
+    assert np.allclose(filtered["points"], points[[0, 1]])
+    assert filtered["lines"].tolist() == [[0, 1]]
+    assert filtered["kept_point_ids"].tolist() == [0, 1]
+    assert filtered["dropped_point_ids"].tolist() == [2, 3]
+    assert filtered["point_metadata"]["spline_id"].tolist() == [4, 4]
+    assert filtered["point_metadata"]["spline_order"].tolist() == [0, 1]
+    assert np.allclose(filtered["point_metadata"]["radius"], [0.1, 0.2])
+
+
+def test_verify_prescribed_points_requires_exact_coordinate_matches():
+    nodes = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+        ],
+        dtype=float,
+    )
+    prescribed_points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.99, 0.0, 0.0],
+        ],
+        dtype=float,
+    )
+
+    with pytest.raises(RuntimeError, match="does not contain all prescribed spline points"):
+        constrained_mod.verify_prescribed_points(nodes, prescribed_points, tol=1e-6)
+
+
+def test_tetrahedralize_with_prescribed_points_uses_exact_insertion_switches(monkeypatch):
+    surface = _surface()
+    prescribed_points = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.5, 0.0, 0.0],
+            [1.5, 0.0, 0.0],
+        ],
+        dtype=float,
+    )
+    prescribed_lines = np.array([[0, 1], [1, 2]], dtype=np.int64)
+    point_metadata = {
+        "spline_id": np.array([3, 3, 3], dtype=np.int32),
+        "spline_order": np.array([0, 1, 2], dtype=np.int32),
+        "radius": np.array([0.1, 0.1, 0.1], dtype=float),
+    }
+    captured = {"switches": []}
+
+    monkeypatch.setattr(constrained_mod, "resolve_tetgen_exe", lambda tetgen_exe=None: "/tmp/tetgen")
+    monkeypatch.setattr(constrained_mod, "write_poly", lambda surface_mesh, path: None)
+
+    def fake_run_tetgen(exe, switches, stem, cwd):
+        captured["switches"].append(switches)
+
+    def fake_write_a_node(points, path):
+        captured["written_points"] = np.asarray(points, dtype=float).copy()
+
+    def fake_read_node(path):
+        nodes = np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.5, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ],
+            dtype=float,
+        )
+        return nodes, {1: 0, 2: 1, 3: 2, 4: 3}
+
+    monkeypatch.setattr(constrained_mod, "run_tetgen", fake_run_tetgen)
+    monkeypatch.setattr(constrained_mod, "write_a_node", fake_write_a_node)
+    monkeypatch.setattr(constrained_mod, "read_node", fake_read_node)
+    monkeypatch.setattr(constrained_mod, "read_ele", lambda path, index_map: np.array([[0, 1, 2, 3]], dtype=np.int64))
+
+    grid, nodes, elems, meta = constrained_mod.tetrahedralize_with_prescribed_points(
+        surface,
+        prescribed_points,
+        prescribed_lines=prescribed_lines,
+        point_metadata=point_metadata,
+        verify_tol=1e-6,
+    )
+
+    assert captured["switches"] == ["pq1.1/10.0Q", "riJMQ"]
+    assert np.allclose(captured["written_points"], prescribed_points[:2])
+    assert meta["line_count"] == 1
+    assert meta["original_point_count"] == 3
+    assert meta["retained_point_count"] == 2
+    assert meta["dropped_point_count"] == 1
+    assert meta["dropped_point_ids"] == [2]
+    assert meta["unique_node_count"] == 2
+    assert np.isclose(meta["max_assignment_distance"], 0.0)
+    assert meta["insertion_switches"] == "riJMQ"
+    assert int(grid.field_data["centerline_constraint_count"][0]) == 2
+    assert int(grid.field_data["centerline_constraint_line_count"][0]) == 1
+    assert int(grid.field_data["centerline_constraint_original_count"][0]) == 3
+    assert int(grid.field_data["centerline_constraint_dropped_count"][0]) == 1
+    assert int(grid.field_data["centerline_constraint_unique_node_count"][0]) == 2
+    assert np.isclose(float(grid.field_data["centerline_constraint_assignment_max_distance"][0]), 0.0)
+    assert int(grid.field_data["centerline_constraint_tolerance_exceeded_count"][0]) == 0
+    assert np.array_equal(grid.point_data["constrained_point"], np.array([1, 1, 0, 0], dtype=np.uint8))
+    assert np.array_equal(grid.point_data["centerline_node"], np.array([1, 1, 0, 0], dtype=np.uint8))
+    assert np.array_equal(grid.point_data["centerline_spline_id"][:2], np.array([3, 3], dtype=np.int32))
+    assert np.array_equal(grid.point_data["centerline_spline_order"][:2], np.array([0, 1], dtype=np.int32))
+    assert np.allclose(grid.point_data["centerline_radius"][:2], [0.1, 0.1])
+    assert nodes.shape == (4, 3)
+    assert elems.shape == (1, 4)

--- a/test/test_zerod_gui_pipeline.py
+++ b/test/test_zerod_gui_pipeline.py
@@ -1,5 +1,6 @@
 import pytest
 import sys
+import types
 
 pytest.importorskip("PySide6")
 
@@ -33,6 +34,65 @@ def test_build_0d_pipeline_steps_disable_gui_unfriendly_outputs(monkeypatch, tmp
     assert steps[0].args[-1].endswith("run.py")
     assert steps[1].env["SVV_0D_RENDER_SCREENSHOTS"] == "0"
     assert steps[1].env["SVV_0D_DISABLE_TQDM"] == "1"
+
+    _close_gui(app, gui)
+
+
+def test_gui_exposes_constrained_tissue_mesh_action(monkeypatch):
+    app, gui = _make_gui(monkeypatch)
+
+    assert gui.build_constrained_tissue_mesh_action.text() == "Build Constrained Tissue Mesh..."
+
+    _close_gui(app, gui)
+
+
+def test_build_constrained_tissue_mesh_uses_spline_point_constrained_mode(monkeypatch):
+    app, gui = _make_gui(monkeypatch)
+    built = {}
+    import svv.simulation.simulation as simulation_mod
+
+    class _FakeSurface:
+        n_points = 4
+
+    class _FakeVolumeMesh:
+        n_cells = 12
+
+        def extract_surface(self):
+            return _FakeSurface()
+
+    class _FakeSimulation:
+        def __init__(self, obj):
+            built["obj"] = obj
+            self.tissue_domain_volume_meshes = [_FakeVolumeMesh()]
+            self.tissue_constraint_metadata = [{"source": "fake"}]
+
+        def build_meshes(self, **kwargs):
+            built["kwargs"] = kwargs
+
+    fake_obj = types.SimpleNamespace(domain=types.SimpleNamespace(boundary=object()))
+
+    monkeypatch.setattr(gui, "_show_constrained_tissue_mesh_preview", lambda surfaces: built.setdefault("surfaces", list(surfaces)))
+    monkeypatch.setattr(simulation_mod, "Simulation", _FakeSimulation)
+
+    sim, volume_meshes, surfaces = gui._build_constrained_tissue_mesh(
+        fake_obj,
+        spline_sample_points=77,
+        tolerance=1e-5,
+        show_overlay=True,
+    )
+
+    assert isinstance(sim, _FakeSimulation)
+    assert built["obj"] is fake_obj
+    assert built["kwargs"] == {
+        "fluid": False,
+        "tissue": True,
+        "tissue_mesh_type": "spline_point_constrained",
+        "tissue_constraint_spline_sample_points": 77,
+        "tissue_constraint_tolerance": 1e-05,
+    }
+    assert len(volume_meshes) == 1
+    assert len(surfaces) == 1
+    assert built["surfaces"] == surfaces
 
     _close_gui(app, gui)
 


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation

Closes #83.

Standard tissue tetrahedralization does not guarantee that sampled vascular spline points become exact volume-mesh nodes. This prevents reliable preservation of centerline identity and complicates construction of tissue-to-vessel coupling data.

This change adds an opt-in `spline_point_constrained` tissue-mesh mode for tree and connected-forest simulations.

## Release Notes

- Sample, deduplicate, and filter vascular spline constraints to the tissue domain.
- Insert prescribed spline points and line segments through a two-stage TetGen CLI workflow, verify exact coordinate preservation, and retain spline identifiers, ordering, and radius metadata.
- Discover TetGen through an explicit argument, `SVV_TETGEN_PATH`, a packaged executable, or `PATH`.
- Add opt-in cross-platform TetGen CLI build and package-staging support.
- Allow tree and forest spline generation without writing intermediate spline files.
- Add Simulation and GUI controls for building and previewing spline-constrained tissue meshes.
- Add unit and integration coverage for constraint processing, executable selection, simulation behavior, spline export, and GUI wiring.

## Documentation

Added API docstrings, setup command help, GUI labels, and tooltips for the new opt-in workflow. A standalone user guide and executable distribution guidance can be added after the packaging and licensing approach is confirmed.

## Testing

- [x] Dedicated meshing and spline tests — 23 passed with 9 PyVista deprecation or future warnings.
- [x] Complete `test/test_zerod_gui_pipeline.py` module — 14 passed.
- [x] GUI testing used import-only stubs for locally unavailable meshing packages; the exercised GUI paths do not invoke those packages.
- [x] New and modified setup and meshing modules pass Python compilation checks.
- [x] `python setup.py --name` returns `svv`.
- [x] Real packaged TetGen executable build and end-to-end run.
- [x] Large-mesh performance benchmark and executable distribution or licensing review.
- [ ] GitHub Actions operating-system and Python-version matrix.

## Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).