### PR TITLE
Improve large-tree growth scaling by reusing topology and work buffers

### DIFF
--- a/svv/forest/forest.py
+++ b/svv/forest/forest.py
@@ -3,7 +3,7 @@ import os
 from copy import deepcopy
 from scipy.spatial import cKDTree
 from svv.tree.tree import Tree
-from svv.tree.data.data import TreeData
+from svv.tree.data.data import TreeData, TreeMap, serialize_tree_map
 from svv.tree.collision.tree_collision import tree_collision
 from svv.tree.utils.TreeManager import KDTreeManager, USearchTree
 from svv.forest.connect.geodesic import geodesic_constructor
@@ -570,7 +570,7 @@ class Forest(object):
                     # Store only the populated vessel table, not the full
                     # preallocated NaN buffer.
                     'data': trimmed_data,
-                    'vessel_map': dict(tree.vessel_map),
+                    'vessel_map': serialize_tree_map(tree.vessel_map),
                 }
                 if include_timing:
                     tree_dict['times'] = tree.times

--- a/svv/tree/branch/bifurcation.py
+++ b/svv/tree/branch/bifurcation.py
@@ -683,7 +683,8 @@ def add_vessel(tree, **kwargs):
                         start_3_2 = perf_counter()
                         added_vessels = [terminal_vessel, terminal_daughter_vessel, parent_vessel]
                         #new_vessels = tree.data.copy(order='C')
-                        tmp_28 = data[:, 28].copy()
+                        tmp_28 = tree._tmp_28_work[:data.shape[0]]
+                        np.copyto(tmp_28, data[:, 28])
                         #new_vessels = deepcopy(tree.data)
                         change_i = []
                         change_j = []
@@ -732,8 +733,8 @@ def add_vessel(tree, **kwargs):
                             bifurcation_ratios = np.empty((1, 2), dtype=float)
                         N = data.shape[0]
                         W = data.shape[1]
-                        downstream_bif = tree.vessel_map[bifurcation_vessel]["downstream"]
-                        D0 = len(downstream_bif)
+                        downstream_bif = tree.get_downstream_indices(bifurcation_vessel)
+                        D0 = downstream_bif.size
 
                         has_children = not np.any(np.isnan(terminal_daughter_vessel[0, 15:17]))
                         child_updates = 2 if has_children else 0  # matches current logic (either 2 or 0)
@@ -743,19 +744,18 @@ def add_vessel(tree, **kwargs):
                         alt_scale_valid = alt_scale[alt_valid_mask]
 
                         # Count the exact number of updates that update_alt would emit (python fallback semantics)
-                        alt_desc_total = 0
-                        for idx in alt_valid:
-                            alt_desc_total += len(tree.vessel_map[int(idx)]["downstream"])
+                        alt_desc_total = tree.sum_downstream_counts(alt_valid)
 
                         n_update_alt = 1 + (6 * main_idx.size) + alt_desc_total + alt_valid.size
                         n_chunk_3_5 = (2 * D0) + child_updates
                         n_chunk_3_6 = N + W
                         n_total = n_update_alt + n_chunk_3_5 + n_chunk_3_6
 
-                        change_i = np.empty(n_total, dtype=np.intp)
-                        change_j = np.empty(n_total, dtype=np.intp)
-                        new_data = np.empty(n_total, dtype=data.dtype)
-                        old_data = np.empty(n_total, dtype=data.dtype)
+                        tree._ensure_change_work_capacity(n_total, data.dtype)
+                        change_i = tree._change_i_work[:n_total]
+                        change_j = tree._change_j_work[:n_total]
+                        new_data = tree._new_data_work[:n_total]
+                        old_data = tree._old_data_work[:n_total]
                         p = 0
 
                         #change_i.append(0)
@@ -771,28 +771,31 @@ def add_vessel(tree, **kwargs):
 
                         # Main idx updates: (22,25,27,28,23,24) for each main_idx
                         if main_idx.size:
-                            cols_main = np.array([22, 25, 27, 28, 23, 24], dtype=np.intp)
-                            ncols = cols_main.size
-                            rows = np.repeat(main_idx, ncols)
-                            cols = np.tile(cols_main, main_idx.size)
+                            n_main = main_idx.size
+                            n = 6 * n_main
+                            sl = slice(p, p + n)
 
-                            new_mat = np.column_stack(
-                                (
-                                    flows,
-                                    reduced_resistance,
-                                    reduced_length,
-                                    main_scale,
-                                    bifurcation_ratios[:, 0],
-                                    bifurcation_ratios[:, 1],
-                                )
-                            ).astype(data.dtype, copy=False)
-                            old_mat = data[main_idx][:, cols_main].astype(data.dtype, copy=False)
+                            change_i_view = change_i[sl].reshape(n_main, 6)
+                            change_j_view = change_j[sl].reshape(n_main, 6)
+                            new_data_view = new_data[sl].reshape(n_main, 6)
+                            old_data_view = old_data[sl].reshape(n_main, 6)
 
-                            n = rows.size
-                            change_i[p: p + n] = rows
-                            change_j[p: p + n] = cols
-                            new_data[p: p + n] = new_mat.ravel(order="C")
-                            old_data[p: p + n] = old_mat.ravel(order="C")
+                            change_i_view[:] = main_idx[:, None]
+                            change_j_view[:] = tree._main_update_cols
+
+                            new_data_view[:, 0] = flows
+                            new_data_view[:, 1] = reduced_resistance
+                            new_data_view[:, 2] = reduced_length
+                            new_data_view[:, 3] = main_scale
+                            new_data_view[:, 4] = bifurcation_ratios[:, 0]
+                            new_data_view[:, 5] = bifurcation_ratios[:, 1]
+
+                            old_data_view[:, 0] = data[main_idx, 22]
+                            old_data_view[:, 1] = data[main_idx, 25]
+                            old_data_view[:, 2] = data[main_idx, 27]
+                            old_data_view[:, 3] = data[main_idx, 28]
+                            old_data_view[:, 4] = data[main_idx, 23]
+                            old_data_view[:, 5] = data[main_idx, 24]
                             p += n
 
                             tmp_28[main_idx] = main_scale
@@ -815,10 +818,9 @@ def add_vessel(tree, **kwargs):
                         # Alt subtree updates (col 28 for downstream + the alt root itself), and mutate tmp_28
                         for idx, scale in zip(alt_valid, alt_scale_valid):
                             idx_int = int(idx)
-                            ds_list = tree.vessel_map[idx_int]["downstream"]
-                            if ds_list:
-                                ds = np.asarray(ds_list, dtype=np.intp)
-                                m = ds.size
+                            ds = tree.get_downstream_indices(idx_int)
+                            m = ds.size
+                            if m:
                                 change_i[p: p + m] = ds
                                 change_j[p: p + m] = 28
 
@@ -1055,20 +1057,20 @@ def add_vessel(tree, **kwargs):
                         #new_vessels[-1, :] = terminal_daughter_vessel
                         """
                         # --- chunk_3_6: radii for all existing vessels + parent row overwrite ---
-                        tmp_radii = np.empty(N, dtype=data.dtype)
+                        tmp_radii = tree._radius_work[:N]
                         if tree.n_terminals < 10000:
                             np.multiply(tmp_28, root_radius, out=tmp_radii)
                         else:
                             ne_multiply(tmp_28, root_radius, tmp_radii)
 
-                        rows = np.arange(N, dtype=np.intp)
+                        rows = tree._row_idx_cache[:N]
                         change_i[p: p + N] = rows
                         change_j[p: p + N] = 21
                         new_data[p: p + N] = tmp_radii
                         old_data[p: p + N] = data[:, 21]
                         p += N
 
-                        cols = np.arange(W, dtype=np.intp)
+                        cols = tree._col_idx_cache[:W]
                         change_i[p: p + W] = bifurcation_vessel
                         change_j[p: p + W] = cols
                         new_data[p: p + W] = parent_vessel[0, :]
@@ -1503,7 +1505,8 @@ def add_vessel(tree, **kwargs):
                         #new_vessels = deepcopy(tree.data)
                         #new_vessels = tree.data.copy(order='C')
                         #new_vessels = tree.data_copy
-                        tmp_28 = data[:, 28].copy()
+                        tmp_28 = tree._tmp_28_work[:data.shape[0]]
+                        np.copyto(tmp_28, data[:, 28])
                         change_i = []
                         change_j = []
                         new_data = []
@@ -1539,8 +1542,8 @@ def add_vessel(tree, **kwargs):
                             bifurcation_ratios = np.empty((1, 2), dtype=float)
                         N = data.shape[0]
                         W = data.shape[1]
-                        downstream_bif = tree.vessel_map[bifurcation_vessel]["downstream"]
-                        D0 = len(downstream_bif)
+                        downstream_bif = tree.get_downstream_indices(bifurcation_vessel)
+                        D0 = downstream_bif.size
 
                         has_children = not np.any(np.isnan(terminal_daughter_vessel[0, 15:17]))
                         child_updates = 2 if has_children else 0  # matches current logic (either 2 or 0)
@@ -1550,19 +1553,18 @@ def add_vessel(tree, **kwargs):
                         alt_scale_valid = alt_scale[alt_valid_mask]
 
                         # Count the exact number of updates that update_alt would emit (python fallback semantics)
-                        alt_desc_total = 0
-                        for idx in alt_valid:
-                            alt_desc_total += len(tree.vessel_map[int(idx)]["downstream"])
+                        alt_desc_total = tree.sum_downstream_counts(alt_valid)
 
                         n_update_alt = 1 + (6 * main_idx.size) + alt_desc_total + alt_valid.size
                         n_chunk_3_5 = (2 * D0) + child_updates
                         n_chunk_3_6 = N + W
                         n_total = n_update_alt + n_chunk_3_5 + n_chunk_3_6
 
-                        change_i = np.empty(n_total, dtype=np.intp)
-                        change_j = np.empty(n_total, dtype=np.intp)
-                        new_data = np.empty(n_total, dtype=data.dtype)
-                        old_data = np.empty(n_total, dtype=data.dtype)
+                        tree._ensure_change_work_capacity(n_total, data.dtype)
+                        change_i = tree._change_i_work[:n_total]
+                        change_j = tree._change_j_work[:n_total]
+                        new_data = tree._new_data_work[:n_total]
+                        old_data = tree._old_data_work[:n_total]
                         p = 0
 
                         #change_i.append(0)
@@ -1578,28 +1580,31 @@ def add_vessel(tree, **kwargs):
 
                         # Main idx updates: (22,25,27,28,23,24) for each main_idx
                         if main_idx.size:
-                            cols_main = np.array([22, 25, 27, 28, 23, 24], dtype=np.intp)
-                            ncols = cols_main.size
-                            rows = np.repeat(main_idx, ncols)
-                            cols = np.tile(cols_main, main_idx.size)
+                            n_main = main_idx.size
+                            n = 6 * n_main
+                            sl = slice(p, p + n)
 
-                            new_mat = np.column_stack(
-                                (
-                                    flows,
-                                    reduced_resistance,
-                                    reduced_length,
-                                    main_scale,
-                                    bifurcation_ratios[:, 0],
-                                    bifurcation_ratios[:, 1],
-                                )
-                            ).astype(data.dtype, copy=False)
-                            old_mat = data[main_idx][:, cols_main].astype(data.dtype, copy=False)
+                            change_i_view = change_i[sl].reshape(n_main, 6)
+                            change_j_view = change_j[sl].reshape(n_main, 6)
+                            new_data_view = new_data[sl].reshape(n_main, 6)
+                            old_data_view = old_data[sl].reshape(n_main, 6)
 
-                            n = rows.size
-                            change_i[p: p + n] = rows
-                            change_j[p: p + n] = cols
-                            new_data[p: p + n] = new_mat.ravel(order="C")
-                            old_data[p: p + n] = old_mat.ravel(order="C")
+                            change_i_view[:] = main_idx[:, None]
+                            change_j_view[:] = tree._main_update_cols
+
+                            new_data_view[:, 0] = flows
+                            new_data_view[:, 1] = reduced_resistance
+                            new_data_view[:, 2] = reduced_length
+                            new_data_view[:, 3] = main_scale
+                            new_data_view[:, 4] = bifurcation_ratios[:, 0]
+                            new_data_view[:, 5] = bifurcation_ratios[:, 1]
+
+                            old_data_view[:, 0] = data[main_idx, 22]
+                            old_data_view[:, 1] = data[main_idx, 25]
+                            old_data_view[:, 2] = data[main_idx, 27]
+                            old_data_view[:, 3] = data[main_idx, 28]
+                            old_data_view[:, 4] = data[main_idx, 23]
+                            old_data_view[:, 5] = data[main_idx, 24]
                             p += n
 
                             tmp_28[main_idx] = main_scale
@@ -1622,10 +1627,9 @@ def add_vessel(tree, **kwargs):
                         # Alt subtree updates (col 28 for downstream + the alt root itself), and mutate tmp_28
                         for idx, scale in zip(alt_valid, alt_scale_valid):
                             idx_int = int(idx)
-                            ds_list = tree.vessel_map[idx_int]["downstream"]
-                            if ds_list:
-                                ds = np.asarray(ds_list, dtype=np.intp)
-                                m = ds.size
+                            ds = tree.get_downstream_indices(idx_int)
+                            m = ds.size
+                            if m:
                                 change_i[p: p + m] = ds
                                 change_j[p: p + m] = 28
 
@@ -1846,13 +1850,13 @@ def add_vessel(tree, **kwargs):
                         old_data[p: p + W] = data[bifurcation_vessel, :]
                         p += W
                         """
-                        tmp_radii = np.zeros((data.shape[0], 1))
+                        tmp_radii = tree._radius_work[:N]
                         if tree.n_terminals < 10000:
                             #np.multiply(new_vessels[:, 28], new_vessels[0, 21], out=new_vessels[:, 21])
-                            np.multiply(tmp_28, root_radius, out=tmp_radii[:, 0])
+                            np.multiply(tmp_28, root_radius, out=tmp_radii)
                         else:
                             #ne_multiply(new_vessels[:, 28], new_vessels[0, 21], new_vessels[:, 21])
-                            ne_multiply(tmp_28, root_radius, tmp_radii[:, 0])
+                            ne_multiply(tmp_28, root_radius, tmp_radii)
                             #scale_column_with_multiply(new_vessels, 28, new_vessels[0, 21], 21)
                             #multiply_columns(new_vessels)
                         #new_vessels[:, 21] = multiply_elements(new_vessels[:, 28], new_vessels[0, 21])
@@ -1863,13 +1867,13 @@ def add_vessel(tree, **kwargs):
                         #    print('col 28 mismatch')
                         #idxs = np.arange(data.shape[0]).astype(int)
                         #change_i.extend(idxs.tolist())
-                        change_i.extend(range(data.shape[0]))
+                        change_i.extend(tree._row_idx_cache[:N])
                         change_j.extend([21]*data.shape[0])
-                        new_data.extend(tmp_radii.flatten().tolist())
+                        new_data.extend(tmp_radii.tolist())
                         old_data.extend(data[:, 21].tolist())
                         #new_vessels[bifurcation_vessel, :] = parent_vessel
                         change_i.extend([bifurcation_vessel]*data.shape[1])
-                        change_j.extend(np.arange(data.shape[1]).astype(int).tolist())
+                        change_j.extend(tree._col_idx_cache[:W])
                         new_data.extend(parent_vessel[0, :].tolist())
                         old_data.extend(data[bifurcation_vessel, :].tolist())
                         appended_vessels = numpy.vstack([terminal_vessel, terminal_daughter_vessel])

--- a/svv/tree/data/data.py
+++ b/svv/tree/data/data.py
@@ -16,24 +16,214 @@ def _format_indices(index):
     return str(index)
 
 
+class TrackedIndexList(list):
+    """List that notifies a callback whenever its contents change."""
+
+    def __init__(self, values=(), *, on_change=None):
+        super().__init__(values)
+        self._on_change = on_change
+
+    def bind(self, on_change):
+        self._on_change = on_change
+
+    def _mark_changed(self):
+        if self._on_change is not None:
+            self._on_change()
+
+    def append(self, value):
+        super().append(value)
+        self._mark_changed()
+
+    def extend(self, values):
+        super().extend(values)
+        self._mark_changed()
+
+    def insert(self, index, value):
+        super().insert(index, value)
+        self._mark_changed()
+
+    def pop(self, index=-1):
+        value = super().pop(index)
+        self._mark_changed()
+        return value
+
+    def remove(self, value):
+        super().remove(value)
+        self._mark_changed()
+
+    def clear(self):
+        super().clear()
+        self._mark_changed()
+
+    def reverse(self):
+        super().reverse()
+        self._mark_changed()
+
+    def sort(self, *args, **kwargs):
+        super().sort(*args, **kwargs)
+        self._mark_changed()
+
+    def __delitem__(self, index):
+        super().__delitem__(index)
+        self._mark_changed()
+
+    def __setitem__(self, index, value):
+        super().__setitem__(index, value)
+        self._mark_changed()
+
+    def __iadd__(self, values):
+        result = super().__iadd__(values)
+        self._mark_changed()
+        return result
+
+    def __imul__(self, value):
+        result = super().__imul__(value)
+        self._mark_changed()
+        return result
+
+
+class TreeMapEntry(dict):
+    """Tracked adjacency entry for a single vessel."""
+
+    def __init__(self, key, value=None, *, on_downstream_change=None):
+        super().__init__()
+        self._key = int(key)
+        self._on_downstream_change = on_downstream_change
+        payload = {} if value is None else dict(value)
+        self["upstream"] = payload.get("upstream", [])
+        self["downstream"] = payload.get("downstream", [])
+
+    def bind(self, key, on_downstream_change):
+        self._key = int(key)
+        self._on_downstream_change = on_downstream_change
+        for field in ("upstream", "downstream"):
+            if field in self:
+                self[field] = self[field]
+
+    def _notify_downstream_change(self):
+        if self._on_downstream_change is not None:
+            self._on_downstream_change(self._key)
+
+    def _wrap_list(self, field, value):
+        callback = self._notify_downstream_change if field == "downstream" else None
+        if isinstance(value, TrackedIndexList):
+            value.bind(callback)
+            return value
+        return TrackedIndexList(value, on_change=callback)
+
+    def __setitem__(self, field, value):
+        if field in ("upstream", "downstream"):
+            value = self._wrap_list(field, value)
+        super().__setitem__(field, value)
+        if field == "downstream":
+            self._notify_downstream_change()
+
+    def __delitem__(self, field):
+        super().__delitem__(field)
+        if field == "downstream":
+            self._notify_downstream_change()
+
+    def update(self, *args, **kwargs):
+        payload = dict(*args, **kwargs)
+        for key, value in payload.items():
+            self[key] = value
+
+    def pop(self, key, *args):
+        value = super().pop(key, *args)
+        if key == "downstream":
+            self._notify_downstream_change()
+        return value
+
+    def clear(self):
+        had_downstream = "downstream" in self
+        super().clear()
+        if had_downstream:
+            self._notify_downstream_change()
+
+
 class TreeMap(dict):
     """Adjacency map used by :class:`~svv.tree.tree.Tree`.
 
-    Keys are integer vessel indices.  Each value is a dictionary with two
-    well-known entries:
+    Keys are integer vessel indices.  Each value is a tracked adjacency entry
+    with two well-known fields:
 
     - ``"upstream"``: list of immediate parent vessel indices (empty for the
       root segment).
     - ``"downstream"``: list of child vessel indices created during
       bifurcation.
 
-    The growth and connectivity routines populate this mapping so callers can
-    traverse the generated vasculature without re-deriving relationships from
-    :class:`TreeData` each time.
+    Downstream mutations can notify an owning :class:`~svv.tree.tree.Tree` so
+    cached NumPy adjacency views stay coherent with the authoritative Python
+    lists.
     """
-    def __new__(cls, *args, **kwargs):
-        data = super().__new__(cls, *args, **kwargs)
-        return data
+
+    def __init__(self, initial=None, *, on_downstream_change=None):
+        super().__init__()
+        self._on_downstream_change = on_downstream_change
+        if initial is not None:
+            self.update(initial)
+
+    def bind(self, on_downstream_change):
+        self._on_downstream_change = on_downstream_change
+        for key, value in super().items():
+            value.bind(key, self._on_downstream_change)
+
+    def __setitem__(self, key, value):
+        key = int(key)
+        if isinstance(value, TreeMapEntry):
+            value.bind(key, self._on_downstream_change)
+            wrapped = value
+        else:
+            wrapped = TreeMapEntry(
+                key,
+                value,
+                on_downstream_change=self._on_downstream_change,
+            )
+        super().__setitem__(key, wrapped)
+        if self._on_downstream_change is not None:
+            self._on_downstream_change(key)
+
+    def __delitem__(self, key):
+        key = int(key)
+        super().__delitem__(key)
+        if self._on_downstream_change is not None:
+            self._on_downstream_change(key)
+
+    def update(self, *args, **kwargs):
+        payload = dict(*args, **kwargs)
+        for key, value in payload.items():
+            self[key] = value
+
+    def setdefault(self, key, default=None):
+        key = int(key)
+        if key not in self:
+            self[key] = {} if default is None else default
+        return self[key]
+
+    def pop(self, key, *args):
+        key = int(key)
+        value = super().pop(key, *args)
+        if self._on_downstream_change is not None:
+            self._on_downstream_change(key)
+        return value
+
+    def clear(self):
+        super().clear()
+        if self._on_downstream_change is not None:
+            self._on_downstream_change(None)
+
+
+def serialize_tree_map(vessel_map):
+    """Return a plain dict-of-lists representation of a vessel map."""
+
+    plain = {}
+    for key, value in vessel_map.items():
+        plain[int(key)] = {
+            "upstream": list(value.get("upstream", [])),
+            "downstream": list(value.get("downstream", [])),
+        }
+    return plain
+
 
 
 class TreeParameters(object):

--- a/svv/tree/tree.py
+++ b/svv/tree/tree.py
@@ -8,7 +8,7 @@ from copy import deepcopy
 from types import MappingProxyType
 import itertools
 from typing import Optional
-from svv.tree.data.data import TreeData, TreeParameters, TreeMap
+from svv.tree.data.data import TreeData, TreeParameters, TreeMap, serialize_tree_map
 from svv.tree.data.units import UnitSystem
 from svv.tree.branch.root import set_root
 from svv.visualize.tree.show import show
@@ -41,7 +41,6 @@ class Tree(object):
             self.parameters = parameters
             if unit_system is not None:
                 self.parameters.set_unit_system(unit_system)
-        self.vessel_map = TreeMap()
         #self.c_vessel_map = None
         self.physical_clearance = 0.0
         self.domain = None
@@ -58,6 +57,21 @@ class Tree(object):
         self.segment_count = 0
         self._idx_cache = []
         self._col21_cache = []
+        self._row_idx_cache = np.arange(self.preallocation_step, dtype=np.intp)
+        self._col_idx_cache = np.arange(self.preallocate.shape[1], dtype=np.intp)
+        self._radius_work = np.empty(self.preallocation_step, dtype=self.preallocate.dtype)
+        self._tmp_28_work = np.empty(self.preallocation_step, dtype=self.preallocate.dtype)
+        self._change_i_work = np.empty(self.preallocation_step, dtype=np.intp)
+        self._change_j_work = np.empty(self.preallocation_step, dtype=np.intp)
+        self._new_data_work = np.empty(self.preallocation_step, dtype=self.preallocate.dtype)
+        self._old_data_work = np.empty(self.preallocation_step, dtype=self.preallocate.dtype)
+        self._main_update_cols = np.array([22, 25, 27, 28, 23, 24], dtype=np.intp)
+        self._empty_downstream = np.empty(0, dtype=np.intp)
+        self._downstream_idx_cache = np.empty(self.preallocation_step, dtype=object)
+        self._downstream_idx_cache[:] = None
+        self._downstream_count_cache = np.zeros(self.preallocation_step, dtype=np.intp)
+        self._downstream_dirty = np.ones(self.preallocation_step, dtype=bool)
+        self._vessel_map = TreeMap(on_downstream_change=self._mark_downstream_cache_dirty)
         #self.preallocate_connectivity = (np.ones((self.preallocation_step, 3)) * -1).astype(int)
         self.preallocate_midpoints = np.zeros((self.preallocation_step, 3))
         self.times = {'vessels':[],
@@ -89,6 +103,184 @@ class Tree(object):
                       'chunk_4_3':[],
                       'chunk_5':[],
                       'all':[]}
+        self.vessel_map = TreeMap()
+
+    @property
+    def vessel_map(self):
+        return self._vessel_map
+
+    @vessel_map.setter
+    def vessel_map(self, value):
+        if not isinstance(value, TreeMap):
+            value = TreeMap(value)
+        keys = list(value.keys())
+        if keys:
+            self._ensure_adjacency_cache_capacity(max(int(k) for k in keys) + 1)
+        value.bind(self._mark_downstream_cache_dirty)
+        self._vessel_map = value
+        self._downstream_idx_cache[:] = None
+        self._downstream_count_cache[:] = 0
+        self._downstream_dirty[:] = True
+
+    def _ensure_adjacency_cache_capacity(self, required_rows: int) -> None:
+        try:
+            required = int(required_rows)
+        except Exception:
+            return
+        if required <= 0:
+            return
+
+        current = int(getattr(self._downstream_idx_cache, "shape", (0,))[0]) or 0
+        if required <= current:
+            return
+
+        new_size = max(required, max(1, current * 2))
+        new_idx_cache = np.empty(new_size, dtype=object)
+        new_idx_cache[:] = None
+        if current:
+            new_idx_cache[:current] = self._downstream_idx_cache[:current]
+        self._downstream_idx_cache = new_idx_cache
+
+        new_count_cache = np.zeros(new_size, dtype=np.intp)
+        if current:
+            new_count_cache[:current] = self._downstream_count_cache[:current]
+        self._downstream_count_cache = new_count_cache
+
+        new_dirty = np.ones(new_size, dtype=bool)
+        if current:
+            new_dirty[:current] = self._downstream_dirty[:current]
+        self._downstream_dirty = new_dirty
+
+    def _mark_downstream_cache_dirty(self, key=None) -> None:
+        if key is None:
+            self._downstream_dirty[:] = True
+            return
+        idx = int(key)
+        if idx < 0:
+            return
+        self._ensure_adjacency_cache_capacity(idx + 1)
+        self._downstream_dirty[idx] = True
+
+    def _refresh_downstream_cache(self, key: int) -> None:
+        idx = int(key)
+        if idx < 0:
+            return
+        self._ensure_adjacency_cache_capacity(idx + 1)
+        entry = self._vessel_map.get(idx)
+        if entry is None:
+            self._downstream_idx_cache[idx] = self._empty_downstream
+            self._downstream_count_cache[idx] = 0
+        else:
+            downstream = entry.get("downstream", ())
+            if len(downstream):
+                arr = np.asarray(downstream, dtype=np.intp)
+            else:
+                arr = self._empty_downstream
+            self._downstream_idx_cache[idx] = arr
+            self._downstream_count_cache[idx] = arr.size
+        self._downstream_dirty[idx] = False
+
+    def _ensure_downstream_cache_keys(self, keys):
+        keys_arr = np.asarray(keys, dtype=np.intp)
+        if keys_arr.size == 0:
+            return keys_arr
+        self._ensure_adjacency_cache_capacity(int(keys_arr.max()) + 1)
+        for key in np.unique(keys_arr):
+            if self._downstream_dirty[key] or self._downstream_idx_cache[key] is None:
+                self._refresh_downstream_cache(int(key))
+        return keys_arr
+
+    def get_downstream_indices(self, key: int):
+        idx = int(key)
+        if idx < 0:
+            return self._empty_downstream
+        self._ensure_adjacency_cache_capacity(idx + 1)
+        if self._downstream_dirty[idx] or self._downstream_idx_cache[idx] is None:
+            self._refresh_downstream_cache(idx)
+        return self._downstream_idx_cache[idx]
+
+    def get_downstream_count(self, key: int) -> int:
+        idx = int(key)
+        if idx < 0:
+            return 0
+        self._ensure_adjacency_cache_capacity(idx + 1)
+        if self._downstream_dirty[idx] or self._downstream_idx_cache[idx] is None:
+            self._refresh_downstream_cache(idx)
+        return int(self._downstream_count_cache[idx])
+
+    def get_downstream_counts(self, keys):
+        keys_arr = self._ensure_downstream_cache_keys(keys)
+        if keys_arr.size == 0:
+            return np.empty(0, dtype=np.intp)
+        return self._downstream_count_cache[keys_arr]
+
+    def sum_downstream_counts(self, keys) -> int:
+        total = 0
+        max_idx = -1
+        cached_keys = []
+        for key in keys:
+            idx = int(key)
+            if idx < 0:
+                continue
+            cached_keys.append(idx)
+            if idx > max_idx:
+                max_idx = idx
+
+        if max_idx < 0:
+            return 0
+
+        self._ensure_adjacency_cache_capacity(max_idx + 1)
+        for idx in cached_keys:
+            if self._downstream_dirty[idx] or self._downstream_idx_cache[idx] is None:
+                self._refresh_downstream_cache(idx)
+            total += int(self._downstream_count_cache[idx])
+        return total
+
+    def _refresh_growth_work_caches(self) -> None:
+        """
+        Refresh reusable NumPy work buffers tied to `self.preallocate`.
+
+        Tree growth repeatedly needs row indices, a fixed column-index range,
+        and a temporary radius buffer. Reallocating those arrays inside hot
+        growth loops adds avoidable overhead, so keep capacity-sized caches on
+        the tree and refresh them only when the preallocation grows.
+        """
+        capacity = int(getattr(self.preallocate, "shape", (0,))[0]) or 0
+        width = int(getattr(self.preallocate, "shape", (0, 0))[1]) or 0
+        self._row_idx_cache = np.arange(capacity, dtype=np.intp)
+        self._col_idx_cache = np.arange(width, dtype=np.intp)
+        self._radius_work = np.empty(capacity, dtype=self.preallocate.dtype)
+        self._tmp_28_work = np.empty(capacity, dtype=self.preallocate.dtype)
+        self._ensure_adjacency_cache_capacity(capacity)
+
+    def _ensure_change_work_capacity(self, required_updates: int, data_dtype=None) -> None:
+        """
+        Ensure reusable change-log buffers can hold `required_updates` entries.
+
+        Growth staging writes the same four arrays each iteration. Keep them as
+        tree-owned work buffers so chunk_3_4 can reuse storage instead of
+        allocating fresh arrays every time.
+        """
+        try:
+            required = int(required_updates)
+        except Exception:
+            return
+        if required <= 0:
+            return
+
+        dtype = self.preallocate.dtype if data_dtype is None else np.dtype(data_dtype)
+        current = int(getattr(self._change_i_work, "shape", (0,))[0]) or 0
+        dtype_matches = (
+            self._new_data_work.dtype == dtype and self._old_data_work.dtype == dtype
+        )
+        if required <= current and dtype_matches:
+            return
+
+        new_size = max(required, max(1, current * 2))
+        self._change_i_work = np.empty(new_size, dtype=np.intp)
+        self._change_j_work = np.empty(new_size, dtype=np.intp)
+        self._new_data_work = np.empty(new_size, dtype=dtype)
+        self._old_data_work = np.empty(new_size, dtype=dtype)
 
     def ensure_preallocation(self, required_rows: int) -> None:
         """
@@ -125,6 +317,7 @@ class Tree(object):
         self.preallocate_midpoints = new_midpoints
 
         self.preallocation_step = int(new_size)
+        self._refresh_growth_work_caches()
 
         # Refresh views that commonly point into the preallocated buffers.
         try:
@@ -457,7 +650,7 @@ class Tree(object):
             'metadata': np.array([metadata], dtype=object),
             'parameters': np.array([params_dict], dtype=object),
             'data': np.asarray(self.data),  # TreeData as plain ndarray
-            'vessel_map': np.array([dict(self.vessel_map)], dtype=object),
+            'vessel_map': np.array([serialize_tree_map(self.vessel_map)], dtype=object),
         }
 
         if include_timing:

--- a/test/test_tree_numpy_cache.py
+++ b/test/test_tree_numpy_cache.py
@@ -1,0 +1,125 @@
+import numpy as np
+
+from svv.tree.data.data import TrackedIndexList, serialize_tree_map
+from svv.tree.tree import Tree
+
+
+def test_tree_growth_work_caches_match_preallocation():
+    tree = Tree(preallocation_step=4)
+
+    assert np.array_equal(tree._row_idx_cache, np.arange(4, dtype=np.intp))
+    assert np.array_equal(
+        tree._col_idx_cache,
+        np.arange(tree.preallocate.shape[1], dtype=np.intp),
+    )
+    assert tree._radius_work.shape == (4,)
+    assert tree._tmp_28_work.shape == (4,)
+    assert tree._radius_work.dtype == tree.preallocate.dtype
+    assert tree._tmp_28_work.dtype == tree.preallocate.dtype
+    assert tree._change_i_work.shape == (4,)
+    assert tree._change_j_work.shape == (4,)
+    assert tree._new_data_work.shape == (4,)
+    assert tree._old_data_work.shape == (4,)
+    assert np.array_equal(tree._main_update_cols, np.array([22, 25, 27, 28, 23, 24], dtype=np.intp))
+
+
+def test_tree_growth_work_caches_refresh_on_resize():
+    tree = Tree(preallocation_step=2)
+    old_row_cache = tree._row_idx_cache
+    old_col_cache = tree._col_idx_cache
+    old_radius_work = tree._radius_work
+    old_tmp_28_work = tree._tmp_28_work
+
+    tree.ensure_preallocation(5)
+
+    capacity = tree.preallocate.shape[0]
+    assert capacity >= 5
+    assert tree._row_idx_cache.shape == (capacity,)
+    assert np.array_equal(tree._row_idx_cache[:5], np.arange(5, dtype=np.intp))
+    assert tree._col_idx_cache.shape == (tree.preallocate.shape[1],)
+    assert np.array_equal(
+        tree._col_idx_cache,
+        np.arange(tree.preallocate.shape[1], dtype=np.intp),
+    )
+    assert tree._radius_work.shape == (capacity,)
+    assert tree._tmp_28_work.shape == (capacity,)
+    assert tree._radius_work.dtype == tree.preallocate.dtype
+    assert tree._tmp_28_work.dtype == tree.preallocate.dtype
+    assert tree._row_idx_cache is not old_row_cache
+    assert tree._col_idx_cache is not old_col_cache
+    assert tree._radius_work is not old_radius_work
+    assert tree._tmp_28_work is not old_tmp_28_work
+
+
+def test_tree_change_work_caches_refresh_on_demand():
+    tree = Tree(preallocation_step=2)
+    old_change_i = tree._change_i_work
+    old_change_j = tree._change_j_work
+    old_new_data = tree._new_data_work
+    old_old_data = tree._old_data_work
+
+    tree._ensure_change_work_capacity(7, np.float32)
+
+    assert tree._change_i_work.shape == (7,)
+    assert tree._change_j_work.shape == (7,)
+    assert tree._new_data_work.shape == (7,)
+    assert tree._old_data_work.shape == (7,)
+    assert tree._new_data_work.dtype == np.float32
+    assert tree._old_data_work.dtype == np.float32
+    assert tree._change_i_work is not old_change_i
+    assert tree._change_j_work is not old_change_j
+    assert tree._new_data_work is not old_new_data
+    assert tree._old_data_work is not old_old_data
+
+
+def test_tree_downstream_cache_refreshes_after_direct_mutation():
+    tree = Tree(preallocation_step=2)
+    tree.vessel_map = {
+        0: {"upstream": [], "downstream": [1, 2]},
+        1: {"upstream": [0], "downstream": []},
+        2: {"upstream": [0], "downstream": []},
+    }
+
+    assert isinstance(tree.vessel_map[0]["downstream"], TrackedIndexList)
+    assert np.array_equal(tree.get_downstream_indices(0), np.array([1, 2], dtype=np.intp))
+    assert tree.get_downstream_count(0) == 2
+
+    tree.vessel_map[0]["downstream"].append(3)
+
+    assert np.array_equal(tree.get_downstream_indices(0), np.array([1, 2, 3], dtype=np.intp))
+    assert tree.get_downstream_count(0) == 3
+
+    tree.vessel_map[0]["downstream"] = [4, 5]
+
+    assert np.array_equal(tree.get_downstream_indices(0), np.array([4, 5], dtype=np.intp))
+    assert tree.get_downstream_count(0) == 2
+
+
+def test_tree_downstream_cache_refreshes_after_map_replacement_and_serializes_plain_lists():
+    tree = Tree(preallocation_step=2)
+    tree.vessel_map = {7: {"upstream": [], "downstream": [8, 9]}}
+
+    assert np.array_equal(tree.get_downstream_indices(7), np.array([8, 9], dtype=np.intp))
+    assert tree.get_downstream_count(7) == 2
+
+    serialized = serialize_tree_map(tree.vessel_map)
+
+    assert serialized == {7: {"upstream": [], "downstream": [8, 9]}}
+    assert isinstance(serialized[7]["downstream"], list)
+    assert not isinstance(serialized[7]["downstream"], TrackedIndexList)
+
+
+def test_tree_sum_downstream_counts_counts_duplicates_and_refreshes_dirty_entries():
+    tree = Tree(preallocation_step=4)
+    tree.vessel_map = {
+        0: {"upstream": [], "downstream": [1, 2]},
+        1: {"upstream": [0], "downstream": [3]},
+        2: {"upstream": [0], "downstream": []},
+        3: {"upstream": [1], "downstream": []},
+    }
+
+    assert tree.sum_downstream_counts(np.array([0, 1, 0, -1], dtype=np.intp)) == 5
+
+    tree.vessel_map[1]["downstream"].append(4)
+
+    assert tree.sum_downstream_counts(np.array([1, 0], dtype=np.intp)) == 4


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation

Closes #84.

Large-tree growth repeatedly converts downstream adjacency lists to NumPy arrays and allocates temporary index, radius, and change-log buffers in the `chunk_3` growth path. This overhead increases with tree size and limits scaling.

## Release Notes

- Add mutation-tracked vessel-map entries that invalidate cached downstream adjacency arrays when topology changes.
- Reuse capacity-sized row-index, column-index, radius, scaling, and change-log buffers during tree growth.
- Refresh capacity-dependent work buffers when tree preallocation expands.
- Use cached downstream arrays and counts while staging bifurcation updates.
- Serialize vessel maps as plain dictionaries and lists for tree and forest persistence.
- Add regression coverage for buffer allocation, resizing, adjacency invalidation, aggregate counts, and serialization.

## Documentation

Added implementation docstrings for the tracked topology containers, downstream caches, and reusable growth buffers. The public tree-growth API is unchanged.

## Testing

- [x] Focused tree cache tests — 6 passed.
- [x] Combined cache, spline-constrained simulation, and spline serialization tests — 23 passed with 5 existing PyVista warnings.
- [x] Modified modules and the new test file pass Python compilation checks.
- [x] `git diff --check upstream/main...HEAD`.
- [ ] Reproducible before-and-after large-tree growth benchmark.
- [ ] GitHub Actions operating-system and Python-version matrix.
- Local tests used import-only stubs for unavailable meshing packages; the exercised cache and serialization paths do not invoke those packages.

## Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).