### PR TITLE
Coalesce VTK renders and improve generation-panel usability

### DIFF
--- a/svv/visualize/gui/main_window.py
+++ b/svv/visualize/gui/main_window.py
@@ -467,6 +467,7 @@ class VascularizeGUI(QMainWindow):
         self._zerod_stderr_buffer = ""
         self._constrained_tissue_preview_actors = []
         self._last_constrained_tissue_simulation = None
+        self._solution_inspector = None
 
         # Persistent layout
         self.settings = QSettings("SimVascular", "svVascularize")
@@ -736,9 +737,7 @@ class VascularizeGUI(QMainWindow):
         self.addDockWidget(Qt.BottomDockWidgetArea, self.info_dock)
         self.info_dock.hide()  # Hidden by default
 
-        # Solution inspector panel (dockable; created up front but hidden)
-        from svv.visualize.gui.solution_inspector import SolutionInspectorWidget
-
+        # Solution inspector panel (dockable; heavy contents are created lazily)
         self.solution_dock = QDockWidget("Solution Inspector", self)
         self.solution_dock.setObjectName("SolutionInspectorDock")
         self.solution_dock.setAllowedAreas(
@@ -748,10 +747,14 @@ class VascularizeGUI(QMainWindow):
         self.solution_dock.setFeatures(
             QDockWidget.DockWidgetClosable | QDockWidget.DockWidgetMovable | QDockWidget.DockWidgetFloatable
         )
-        self.solution_inspector = SolutionInspectorWidget(self.solution_dock)
-        self.solution_dock.setWidget(self.solution_inspector)
+        placeholder = QLabel("Solution Inspector will open when needed.")
+        placeholder.setAlignment(Qt.AlignCenter)
+        placeholder.setWordWrap(True)
+        placeholder.setStyleSheet(f"padding: 24px; color: {CADTheme.get_color('text', 'secondary')};")
+        self.solution_dock.setWidget(placeholder)
         self.addDockWidget(Qt.RightDockWidgetArea, self.solution_dock)
         self.solution_dock.hide()
+        self.solution_dock.visibilityChanged.connect(self._on_solution_dock_visibility_changed)
 
     def _create_menu_bar(self):
         """Create the menu bar."""
@@ -786,7 +789,7 @@ class VascularizeGUI(QMainWindow):
         # Domain edge toggle (View menu only)
         self.action_toggle_domain_edges = QAction("Domain Edges", self)
         self.action_toggle_domain_edges.setCheckable(True)
-        self.action_toggle_domain_edges.setChecked(True)
+        self.action_toggle_domain_edges.setChecked(False)
         self.action_toggle_domain_edges.setStatusTip("Toggle domain edge display")
         self.action_toggle_domain_edges.setToolTip("Toggle Domain Edges")
         self.action_toggle_domain_edges.triggered.connect(
@@ -995,6 +998,35 @@ class VascularizeGUI(QMainWindow):
 
         self.update_status("Domain loaded successfully")
         self.update_object_count()
+
+    @property
+    def solution_inspector(self):
+        """Return the lazily created Solution Inspector widget."""
+        return self._ensure_solution_inspector()
+
+    def _ensure_solution_inspector(self):
+        """Create the Solution Inspector the first time it is actually needed."""
+        if self._solution_inspector is not None:
+            return self._solution_inspector
+        if not hasattr(self, "solution_dock") or self.solution_dock is None:
+            return None
+
+        from svv.visualize.gui.solution_inspector import SolutionInspectorWidget
+
+        old_widget = self.solution_dock.widget()
+        self._solution_inspector = SolutionInspectorWidget(self.solution_dock)
+        self.solution_dock.setWidget(self._solution_inspector)
+        if old_widget is not None:
+            try:
+                old_widget.deleteLater()
+            except Exception:
+                pass
+        return self._solution_inspector
+
+    def _on_solution_dock_visibility_changed(self, visible: bool):
+        """Instantiate the inspector when users open the dock from the View menu."""
+        if visible:
+            self._ensure_solution_inspector()
 
     def load_domain_dialog(self):
         """Open file dialog to load domain."""
@@ -2400,7 +2432,7 @@ class VascularizeGUI(QMainWindow):
         pvd_path = os.path.join(export_path, "timeseries", "timeseries.pvd")
         if not os.path.isfile(pvd_path):
             return None
-        inspector = getattr(self, "solution_inspector", None)
+        inspector = self._ensure_solution_inspector()
         if inspector is None:
             return None
         self._show_solution_inspector()
@@ -2684,6 +2716,16 @@ class VascularizeGUI(QMainWindow):
         """Update status bar message."""
         self.status_message.setText(message)
 
+    def show_toast(self, message: str, duration_ms: int = 1800):
+        """Show a non-blocking status/HUD message."""
+        self.update_status(message)
+        vtk_widget = getattr(self, "vtk_widget", None)
+        if vtk_widget is not None and hasattr(vtk_widget, "show_hud"):
+            try:
+                vtk_widget.show_hud(message, duration_ms=duration_ms)
+            except Exception:
+                pass
+
     def log_output(self, message: str):
         """Append a message to the output console."""
         if hasattr(self, "output_console") and self.output_console:
@@ -2743,6 +2785,7 @@ class VascularizeGUI(QMainWindow):
     def _show_solution_inspector(self):
         """Show the Solution Inspector dockable panel."""
         if hasattr(self, "solution_dock") and self.solution_dock is not None:
+            self._ensure_solution_inspector()
             self.solution_dock.show()
             self.solution_dock.raise_()
 
@@ -2927,9 +2970,9 @@ class VascularizeGUI(QMainWindow):
                 self.vtk_widget.shutdown()
             except Exception:
                 pass
-        if hasattr(self, "solution_inspector") and self.solution_inspector is not None:
+        if getattr(self, "_solution_inspector", None) is not None:
             try:
-                self.solution_inspector.shutdown()
+                self._solution_inspector.shutdown()
             except Exception:
                 pass
 

--- a/svv/visualize/gui/parameter_panel.py
+++ b/svv/visualize/gui/parameter_panel.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (
     QPushButton, QLabel, QSpinBox, QDoubleSpinBox,
     QComboBox, QCheckBox, QScrollArea, QFormLayout,
     QMessageBox, QProgressDialog, QSizePolicy,
-    QToolButton, QToolTip
+    QToolButton, QToolTip, QGridLayout
 )
 import numpy as np
 import threading
@@ -139,6 +139,38 @@ _PARAM_DESCRIPTIONS = {
 }
 
 
+class CollapsibleGroupBox(QGroupBox):
+    """Checkable group box that hides its contents when collapsed."""
+
+    def __init__(self, title: str, checked: bool = True, parent=None):
+        super().__init__(title, parent)
+        self.setCheckable(True)
+        self.setChecked(checked)
+        self.toggled.connect(self._set_content_visible)
+
+    def setLayout(self, layout):
+        super().setLayout(layout)
+        QTimer.singleShot(0, lambda: self._set_content_visible(self.isChecked()))
+
+    def _set_content_visible(self, visible: bool):
+        layout = self.layout()
+        if layout is None:
+            return
+        for i in range(layout.count()):
+            self._set_item_visible(layout.itemAt(i), visible)
+
+    def _set_item_visible(self, item, visible: bool):
+        if item is None:
+            return
+        widget = item.widget()
+        if widget is not None:
+            widget.setVisible(visible)
+        child_layout = item.layout()
+        if child_layout is not None:
+            for i in range(child_layout.count()):
+                self._set_item_visible(child_layout.itemAt(i), visible)
+
+
 class ParameterPanel(QWidget):
     """
     Widget for configuring Tree and Forest generation parameters.
@@ -234,6 +266,23 @@ class ParameterPanel(QWidget):
         except Exception:
             pass
 
+    @staticmethod
+    def _configure_combo(combo: QComboBox, *, min_chars: int = 12, max_width: int = 220):
+        """Keep combo boxes from expanding docks beyond useful widths."""
+        combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        combo.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
+        combo.setMinimumContentsLength(min_chars)
+        combo.setMinimumWidth(min(120, max_width))
+        combo.setMaximumWidth(max_width)
+
+    @staticmethod
+    def _configure_form(form: QFormLayout):
+        """Use compact wrapping forms that behave well in narrow docks."""
+        form.setSpacing(10)
+        form.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        form.setRowWrapPolicy(QFormLayout.WrapLongRows)
+        form.setLabelAlignment(Qt.AlignLeft)
+
     def _init_ui(self):
         """Initialize the user interface."""
         layout = QVBoxLayout()
@@ -258,8 +307,7 @@ class ParameterPanel(QWidget):
         mode_group.setLayout(mode_layout)
 
         self.mode_combo = QComboBox()
-        self.mode_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        self.mode_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self._configure_combo(self.mode_combo, min_chars=16, max_width=240)
         self.mode_combo.addItem("Tree (single)")
         self.mode_combo.addItem("Forest (multiple)")
         self.mode_combo.setMaxVisibleItems(100)
@@ -272,41 +320,43 @@ class ParameterPanel(QWidget):
         # Tree parameters
         tree_params_group = QGroupBox("Tree Parameters")
         tree_form = QFormLayout()
-        tree_form.setSpacing(10)
-        tree_form.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        self._configure_form(tree_form)
         tree_params_group.setLayout(tree_form)
 
         # Unit system selection (dropdowns for base units)
         unit_row = QWidget()
-        unit_layout = QHBoxLayout(unit_row)
+        unit_layout = QGridLayout(unit_row)
         unit_layout.setContentsMargins(0, 0, 0, 0)
-        unit_layout.setSpacing(6)
+        unit_layout.setHorizontalSpacing(6)
+        unit_layout.setVerticalSpacing(4)
 
         self.length_unit_combo = QComboBox()
+        self._configure_combo(self.length_unit_combo, min_chars=5, max_width=96)
         self.length_unit_combo.addItems(sorted(_LENGTH_UNITS.keys()))
         self.length_unit_combo.setCurrentText(self.tree_unit_system.base.length.symbol)
         self.length_unit_combo.setToolTip("Base length unit used for TreeParameters values")
         self.length_unit_combo.currentTextChanged.connect(self._on_unit_system_changed)
-        unit_layout.addWidget(QLabel("L:"))
-        unit_layout.addWidget(self.length_unit_combo)
+        unit_layout.addWidget(QLabel("L:"), 0, 0)
+        unit_layout.addWidget(self.length_unit_combo, 0, 1)
 
         self.mass_unit_combo = QComboBox()
+        self._configure_combo(self.mass_unit_combo, min_chars=5, max_width=96)
         self.mass_unit_combo.addItems(sorted(_MASS_UNITS.keys()))
         self.mass_unit_combo.setCurrentText(self.tree_unit_system.base.mass.symbol)
         self.mass_unit_combo.setToolTip("Base mass unit used for TreeParameters values")
         self.mass_unit_combo.currentTextChanged.connect(self._on_unit_system_changed)
-        unit_layout.addWidget(QLabel("M:"))
-        unit_layout.addWidget(self.mass_unit_combo)
+        unit_layout.addWidget(QLabel("M:"), 1, 0)
+        unit_layout.addWidget(self.mass_unit_combo, 1, 1)
 
         self.time_unit_combo = QComboBox()
+        self._configure_combo(self.time_unit_combo, min_chars=5, max_width=96)
         self.time_unit_combo.addItems(sorted(_TIME_UNITS.keys()))
         self.time_unit_combo.setCurrentText(self.tree_unit_system.base.time.symbol)
         self.time_unit_combo.setToolTip("Base time unit used for TreeParameters values")
         self.time_unit_combo.currentTextChanged.connect(self._on_unit_system_changed)
-        unit_layout.addWidget(QLabel("T:"))
-        unit_layout.addWidget(self.time_unit_combo)
-
-        unit_layout.addStretch()
+        unit_layout.addWidget(QLabel("T:"), 2, 0)
+        unit_layout.addWidget(self.time_unit_combo, 2, 1)
+        unit_layout.setColumnStretch(1, 1)
         tree_form.addRow(self._make_label_with_info("Unit System:", _PARAM_DESCRIPTIONS['unit_system']), unit_row)
 
         # Number of vessels
@@ -345,26 +395,25 @@ class ParameterPanel(QWidget):
 
         # Per-tree override selector (shown in forest mode)
         self.tree_override_widget = QWidget()
-        override_layout = QHBoxLayout()
+        override_layout = QGridLayout()
         override_layout.setContentsMargins(0, 0, 0, 0)
-        override_layout.setSpacing(6)
+        override_layout.setHorizontalSpacing(6)
+        override_layout.setVerticalSpacing(4)
         self.tree_override_widget.setLayout(override_layout)
-        override_layout.addWidget(QLabel("Edit Tree:"))
+        override_layout.addWidget(QLabel("Edit Tree:"), 0, 0, 1, 2)
         self.override_network_combo = QComboBox()
-        self.override_network_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        self.override_network_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self._configure_combo(self.override_network_combo, min_chars=10, max_width=180)
         self.override_network_combo.setMaxVisibleItems(100)
         self.override_tree_combo = QComboBox()
-        self.override_tree_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        self.override_tree_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self._configure_combo(self.override_tree_combo, min_chars=8, max_width=160)
         self.override_tree_combo.setMaxVisibleItems(100)
         self.override_network_combo.currentIndexChanged.connect(self._on_tree_override_changed)
         self.override_tree_combo.currentIndexChanged.connect(self._on_tree_override_changed)
-        override_layout.addWidget(QLabel("Network"))
-        override_layout.addWidget(self.override_network_combo)
-        override_layout.addWidget(QLabel("Tree"))
-        override_layout.addWidget(self.override_tree_combo)
-        override_layout.addStretch()
+        override_layout.addWidget(QLabel("Network"), 1, 0)
+        override_layout.addWidget(self.override_network_combo, 1, 1)
+        override_layout.addWidget(QLabel("Tree"), 2, 0)
+        override_layout.addWidget(self.override_tree_combo, 2, 1)
+        override_layout.setColumnStretch(1, 1)
         tree_form.addRow(self.tree_override_widget)
         self.tree_override_widget.hide()
 
@@ -415,10 +464,9 @@ class ParameterPanel(QWidget):
         scroll_layout.addWidget(tree_params_group)
 
         # Forest parameters (initially hidden)
-        self.forest_params_group = QGroupBox("Forest Parameters")
+        self.forest_params_group = CollapsibleGroupBox("Forest Parameters", checked=True)
         forest_form = QFormLayout()
-        forest_form.setSpacing(10)
-        forest_form.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        self._configure_form(forest_form)
         self.forest_params_group.setLayout(forest_form)
 
         # Number of networks (Forest only)
@@ -456,6 +504,7 @@ class ParameterPanel(QWidget):
 
         # Curve type used when connecting trees into networks
         self.curve_type_combo = QComboBox()
+        self._configure_combo(self.curve_type_combo, min_chars=10, max_width=180)
         # Display labels mapped to internal curve_type strings used by svv.forest.connect.curve.Curve
         self.curve_type_combo.addItem("Bezier", userData="Bezier")
         self.curve_type_combo.addItem("Catmull-Rom", userData="CatmullRom")
@@ -483,10 +532,9 @@ class ParameterPanel(QWidget):
         self.forest_params_group.hide()
 
         # Advanced parameters
-        advanced_group = QGroupBox("Advanced Parameters")
+        advanced_group = CollapsibleGroupBox("Advanced Parameters", checked=False)
         advanced_form = QFormLayout()
-        advanced_form.setSpacing(10)
-        advanced_form.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        self._configure_form(advanced_form)
         advanced_group.setLayout(advanced_form)
 
         self.random_seed_spin = QSpinBox()
@@ -1284,18 +1332,18 @@ class ParameterPanel(QWidget):
         else:
             if self.parent_gui:
                 self.parent_gui.log_output("[Forest] connected")
-                self.parent_gui.update_status("Forest connected")
+                if hasattr(self.parent_gui, "show_toast"):
+                    self.parent_gui.show_toast("Forest connected")
+                else:
+                    self.parent_gui.update_status("Forest connected")
                 try:
                     self.parent_gui.vtk_widget.draw_forest(forest)
                 except Exception:
                     # Keep UI responsive even if redraw fails
                     pass
             if show_success_dialog:
-                QMessageBox.information(
-                    self,
-                    "Forest Connected",
-                    "Forest connections created successfully."
-                )
+                if self.parent_gui and hasattr(self.parent_gui, "show_toast"):
+                    self.parent_gui.show_toast("Forest connections created")
 
         if hasattr(self, 'connect_now_btn'):
             self.connect_now_btn.setEnabled(True)
@@ -1587,10 +1635,11 @@ class ParameterPanel(QWidget):
             return
 
         # Visualize and store
-        self.parent_gui.vtk_widget.clear_trees()
-        self.parent_gui.vtk_widget.clear_connections()
-        # Group ID ('single', 0) used for visibility toggles
-        self.parent_gui.vtk_widget.add_tree(tree, label="tree_single", group_id=("single", 0))
+        with self.parent_gui.vtk_widget.batch_render():
+            self.parent_gui.vtk_widget.clear_trees()
+            self.parent_gui.vtk_widget.clear_connections()
+            # Group ID ('single', 0) used for visibility toggles
+            self.parent_gui.vtk_widget.add_tree(tree, label="tree_single", group_id=("single", 0))
         self.parent_gui.trees = [tree]
         self.parent_gui.forest = None
 
@@ -1602,17 +1651,11 @@ class ParameterPanel(QWidget):
                 pass
 
         if self.parent_gui:
-            self.parent_gui.update_status(f"Tree generated successfully with {tree.n_terminals} vessels")
+            if hasattr(self.parent_gui, "show_toast"):
+                self.parent_gui.show_toast(f"Tree generated: {tree.n_terminals} vessels")
+            else:
+                self.parent_gui.update_status(f"Tree generated successfully with {tree.n_terminals} vessels")
             self.parent_gui.log_output(f"[Tree] done: {tree.n_terminals} vessels")
-
-        QMessageBox.information(
-            self,
-            "Success",
-            f"Tree generated successfully!\n\n"
-            f"Total vessels: {tree.n_terminals}\n"
-            f"Physical clearance: {result.get('physical_clearance')}\n"
-            f"Convexity tolerance: {result.get('convexity_tolerance')}"
-        )
 
     def _on_forest_generated(self, result):
         forest = result.get('forest')
@@ -1635,26 +1678,17 @@ class ParameterPanel(QWidget):
 
         total_vessels = result.get('total_vessels', 0)
         n_networks = result.get('n_networks', 0)
-        compete = result.get('compete', False)
-        physical_clearance = result.get('physical_clearance')
 
         if self.parent_gui:
-            self.parent_gui.update_status(
-                f"Forest generated successfully with {total_vessels} vessels across {n_networks} networks"
-            )
+            if hasattr(self.parent_gui, "show_toast"):
+                self.parent_gui.show_toast(f"Forest generated: {total_vessels} vessels across {n_networks} networks")
+            else:
+                self.parent_gui.update_status(
+                    f"Forest generated successfully with {total_vessels} vessels across {n_networks} networks"
+                )
             self.parent_gui.log_output(f"[Forest] done: {total_vessels} vessels across {n_networks} networks")
             if forest.connections is None:
                 self.parent_gui.log_output("[Forest] connect pending - click Connect Forest to link trees")
-
-        QMessageBox.information(
-            self,
-            "Success",
-            f"Forest generated successfully!\n\n"
-            f"Total vessels: {total_vessels}\n"
-            f"Networks: {n_networks}\n"
-            f"Competition: {'Enabled' if compete else 'Disabled'}\n"
-            f"Physical clearance: {physical_clearance}"
-        )
 
     def _export_config(self):
         """Export the current configuration."""

--- a/svv/visualize/gui/point_selector.py
+++ b/svv/visualize/gui/point_selector.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QHBoxLayout, QGroupBox,
     QPushButton, QListWidget, QListWidgetItem,
     QLabel, QLineEdit, QCheckBox,
-    QDoubleSpinBox, QComboBox, QSizePolicy, QScrollArea
+    QDoubleSpinBox, QComboBox, QSizePolicy, QScrollArea, QGridLayout
 )
 from PySide6.QtCore import Signal, Qt, QSignalBlocker
 from svv.visualize.gui.theme import CADTheme, CADIcons
@@ -40,6 +40,15 @@ class PointSelectorWidget(QWidget):
         # per-network tree count until the ParameterPanel sets explicit values.
         self._n_trees_per_network = [max(1, self.tree_combo.count())]
         self.set_network_count(1)
+
+    @staticmethod
+    def _configure_combo(combo: QComboBox, *, min_chars: int = 10, max_width: int = 180):
+        """Keep combo boxes useful in narrow docked layouts."""
+        combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        combo.setSizeAdjustPolicy(QComboBox.AdjustToMinimumContentsLengthWithIcon)
+        combo.setMinimumContentsLength(min_chars)
+        combo.setMinimumWidth(min(120, max_width))
+        combo.setMaximumWidth(max_width)
 
     # ---- Public helpers ----
     def set_network_count(self, count: int):
@@ -140,25 +149,27 @@ class PointSelectorWidget(QWidget):
 
 
         # Current network/tree selection
-        selection_layout = QHBoxLayout()
-        selection_layout.addWidget(QLabel("Network:"))
+        selection_layout = QGridLayout()
+        selection_layout.setContentsMargins(0, 0, 0, 0)
+        selection_layout.setHorizontalSpacing(6)
+        selection_layout.setVerticalSpacing(4)
+        selection_layout.addWidget(QLabel("Network:"), 0, 0)
         self.network_combo = QComboBox()
-        self.network_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        self.network_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self._configure_combo(self.network_combo)
         self.network_combo.setMaxVisibleItems(100)
         self.network_combo.addItem("Network 0")
         self.network_combo.currentIndexChanged.connect(self._on_network_selection_changed)
-        selection_layout.addWidget(self.network_combo)
+        selection_layout.addWidget(self.network_combo, 0, 1)
 
-        selection_layout.addWidget(QLabel("Tree:"))
+        selection_layout.addWidget(QLabel("Tree:"), 1, 0)
         self.tree_combo = QComboBox()
-        self.tree_combo.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        self.tree_combo.setSizeAdjustPolicy(QComboBox.AdjustToContents)
+        self._configure_combo(self.tree_combo)
         self.tree_combo.setMaxVisibleItems(100)
         self.tree_combo.addItem("Tree 0")
         self.tree_combo.addItem("Tree 1")
         self.tree_combo.currentIndexChanged.connect(self._on_tree_changed)
-        selection_layout.addWidget(self.tree_combo)
+        selection_layout.addWidget(self.tree_combo, 1, 1)
+        selection_layout.setColumnStretch(1, 1)
         group_layout.addLayout(selection_layout)
 
         # Point list
@@ -195,6 +206,7 @@ class PointSelectorWidget(QWidget):
         coord_layout = QHBoxLayout()
         coord_layout.addWidget(QLabel("Position:"))
         self.coord_label = QLabel("(0.0, 0.0, 0.0)")
+        self.coord_label.setWordWrap(True)
         coord_layout.addWidget(self.coord_label)
         coord_layout.addStretch()
         details_layout.addLayout(coord_layout)
@@ -206,31 +218,34 @@ class PointSelectorWidget(QWidget):
         details_layout.addWidget(self.use_direction_cb)
 
         # Direction inputs
-        direction_layout = QHBoxLayout()
-        direction_layout.addWidget(QLabel("Direction:"))
+        direction_layout = QGridLayout()
+        direction_layout.setContentsMargins(0, 0, 0, 0)
+        direction_layout.setHorizontalSpacing(6)
+        direction_layout.setVerticalSpacing(4)
         self.dir_x = QDoubleSpinBox()
         self.dir_x.setRange(-1.0, 1.0)
         self.dir_x.setSingleStep(0.1)
         self.dir_x.setDecimals(3)
         self.dir_x.valueChanged.connect(self._on_direction_changed)
-        direction_layout.addWidget(QLabel("X:"))
-        direction_layout.addWidget(self.dir_x)
+        direction_layout.addWidget(QLabel("X:"), 0, 0)
+        direction_layout.addWidget(self.dir_x, 0, 1)
 
         self.dir_y = QDoubleSpinBox()
         self.dir_y.setRange(-1.0, 1.0)
         self.dir_y.setSingleStep(0.1)
         self.dir_y.setDecimals(3)
         self.dir_y.valueChanged.connect(self._on_direction_changed)
-        direction_layout.addWidget(QLabel("Y:"))
-        direction_layout.addWidget(self.dir_y)
+        direction_layout.addWidget(QLabel("Y:"), 1, 0)
+        direction_layout.addWidget(self.dir_y, 1, 1)
 
         self.dir_z = QDoubleSpinBox()
         self.dir_z.setRange(-1.0, 1.0)
         self.dir_z.setSingleStep(0.1)
         self.dir_z.setDecimals(3)
         self.dir_z.valueChanged.connect(self._on_direction_changed)
-        direction_layout.addWidget(QLabel("Z:"))
-        direction_layout.addWidget(self.dir_z)
+        direction_layout.addWidget(QLabel("Z:"), 2, 0)
+        direction_layout.addWidget(self.dir_z, 2, 1)
+        direction_layout.setColumnStretch(1, 1)
 
         details_layout.addLayout(direction_layout)
 
@@ -245,7 +260,8 @@ class PointSelectorWidget(QWidget):
         group_layout.addWidget(details_group)
 
         # Delete and Clear buttons
-        action_layout = QHBoxLayout()
+        action_layout = QVBoxLayout()
+        action_layout.setSpacing(6)
         self.delete_btn = QPushButton("Delete Selected")
         self.delete_btn.clicked.connect(self._delete_selected)
         self.delete_btn.setObjectName("dangerButton")
@@ -594,10 +610,10 @@ class PointSelectorWidget(QWidget):
         """Refresh all point and direction visualizations."""
         if self.parent_gui:
             vtk_widget = self.parent_gui.vtk_widget
-            vtk_widget.clear()
-
-            for i, point_data in enumerate(self.points):
-                self._visualize_point(point_data, i)
+            with vtk_widget.batch_render():
+                vtk_widget.clear()
+                for i, point_data in enumerate(self.points):
+                    self._visualize_point(point_data, i)
 
     def get_configuration(self):
         """

--- a/svv/visualize/gui/vtk_widget.py
+++ b/svv/visualize/gui/vtk_widget.py
@@ -4,6 +4,7 @@ VTK/PyVista widget for 3D domain visualization.
 import os
 import platform
 import sys
+from contextlib import contextmanager
 
 # macOS: force layer-backed views to avoid Qt/VTK view initialization deadlocks.
 if sys.platform == 'darwin':
@@ -478,7 +479,7 @@ class VTKWidget(QWidget):
         self._scale_bar_actor = None
         self._scale_bar_visible = True
         # Domain edge visibility state
-        self._domain_edges_visible = True
+        self._domain_edges_visible = False
         # Grid visibility state
         self._grid_visible = False
         self._grid_actor = None
@@ -517,6 +518,14 @@ class VTKWidget(QWidget):
             "border: 1px solid rgba(122,155,192,180); padding: 6px 10px; border-radius: 6px;"
         )
         self._hud.hide()
+
+        self._render_timer = QTimer(self)
+        self._render_timer.setSingleShot(True)
+        self._render_timer.timeout.connect(self._perform_scheduled_render)
+        self._render_batch_depth = 0
+        self._render_pending = False
+        self._render_batch_delay_ms = 0
+        self._render_in_progress = False
 
     def showEvent(self, event):
         super().showEvent(event)
@@ -785,18 +794,92 @@ class VTKWidget(QWidget):
         self._plotter_init_failed = True
         self._plotter_init_in_progress = False
 
-    def request_render(self, *, delay_ms=None):
-        """Render the plotter and refresh the compatibility viewport when needed."""
+    def request_render(self, *, delay_ms=None, immediate=False):
+        """Schedule a coalesced plotter render.
+
+        Most GUI interactions can wait until Qt returns to the event loop. Using
+        a single-shot timer collapses bursts of actor/style changes into one VTK
+        render, which keeps dense tree and forest updates responsive.
+        """
         if not self.plotter:
             return
+        delay_ms = 0 if delay_ms is None else max(0, int(delay_ms))
+
+        if self._render_batch_depth > 0:
+            was_pending = self._render_pending
+            self._render_pending = True
+            if not was_pending or delay_ms < self._render_batch_delay_ms:
+                self._render_batch_delay_ms = delay_ms
+            return
+
+        if immediate:
+            if self._render_timer.isActive():
+                self._render_timer.stop()
+            self._render_now()
+            return
+
+        self._schedule_render(delay_ms)
+
+    def _schedule_render(self, delay_ms=0):
+        """Start or tighten the pending render timer."""
+        delay_ms = max(0, int(delay_ms))
+        if self._render_timer.isActive():
+            remaining = self._render_timer.remainingTime()
+            if remaining >= 0 and remaining <= delay_ms:
+                return
+            self._render_timer.stop()
+        self._render_timer.start(delay_ms)
+
+    def _perform_scheduled_render(self):
+        """Timer callback for deferred rendering."""
+        if self._render_batch_depth > 0:
+            self._render_pending = True
+            return
+        self._render_now()
+
+    def _render_now(self):
+        """Render immediately, guarding against recursive render requests."""
+        if not self.plotter:
+            self._render_pending = False
+            return
+        if self._render_in_progress:
+            self._render_pending = True
+            return
+        self._render_in_progress = True
         try:
             self.plotter.render()
         except Exception:
-            return
+            pass
+        finally:
+            self._render_in_progress = False
         if self._offscreen_mode and self._blit_widget is not None:
-            if delay_ms is None:
-                delay_ms = 0
-            self._blit_widget.schedule_blit(delay_ms=delay_ms)
+            self._blit_widget.schedule_blit(delay_ms=0)
+        if self._render_pending and self._render_batch_depth == 0:
+            self._render_pending = False
+            self._schedule_render(0)
+
+    @contextmanager
+    def batch_render(self, delay_ms=0):
+        """Defer render requests until a group of scene mutations completes."""
+        self._render_batch_depth += 1
+        previous_delay = self._render_batch_delay_ms
+        if self._render_batch_depth == 1:
+            self._render_batch_delay_ms = max(0, int(delay_ms))
+        try:
+            yield self
+        finally:
+            self._render_batch_depth = max(0, self._render_batch_depth - 1)
+            if self._render_batch_depth == 0:
+                should_render = self._render_pending
+                pending_delay = self._render_batch_delay_ms
+                self._render_pending = False
+                self._render_batch_delay_ms = previous_delay
+                if should_render:
+                    self.request_render(delay_ms=pending_delay)
+
+    def show_hud(self, message: str, duration_ms: int = 1400):
+        """Public wrapper for transient viewport messages."""
+        self._show_hud(message, duration_ms=duration_ms)
 
     def _batched_vessel_sides(self) -> int:
         """Return the tube resolution used for batched vessel meshes."""
@@ -868,6 +951,12 @@ class VTKWidget(QWidget):
         """
         if getattr(self, '_blit_widget', None) is not None:
             self._blit_widget.stop()
+
+        if hasattr(self, '_render_timer') and self._render_timer:
+            try:
+                self._render_timer.stop()
+            except Exception:
+                pass
 
         # Stop scale bar update timer
         if hasattr(self, '_scale_bar_timer') and self._scale_bar_timer:
@@ -1086,6 +1175,35 @@ class VTKWidget(QWidget):
         if hasattr(self, '_scale_bar_widget') and self._scale_bar_widget:
             self._scale_bar_widget.set_unit_label(unit_label)
 
+    @staticmethod
+    def _prepare_domain_surface_mesh(surface):
+        """Return a display mesh with smooth point normals for softer lighting."""
+        if surface is None:
+            return None
+        try:
+            return surface.compute_normals(
+                point_normals=True,
+                cell_normals=False,
+                split_vertices=False,
+                consistent_normals=True,
+                auto_orient_normals=True,
+                feature_angle=180.0,
+                inplace=False,
+            )
+        except TypeError:
+            try:
+                return surface.compute_normals(
+                    point_normals=True,
+                    cell_normals=False,
+                    split_vertices=False,
+                    feature_angle=180.0,
+                    inplace=False,
+                )
+            except Exception:
+                return surface
+        except Exception:
+            return surface
+
     def set_domain(self, domain):
         """
         Set and visualize the domain.
@@ -1107,19 +1225,25 @@ class VTKWidget(QWidget):
         if hasattr(domain, 'boundary') and domain.boundary is not None:
             surface_color = CADTheme.get_color('viewport', 'domain-surface')
             edge_color = CADTheme.get_color('viewport', 'domain-edge')
+            display_boundary = self._prepare_domain_surface_mesh(domain.boundary)
             self.domain_actor = self.plotter.add_mesh(
-                domain.boundary,
+                display_boundary,
                 color=surface_color,
                 opacity=0.35,
                 show_edges=self._domain_edges_visible,
                 edge_color=edge_color,
                 line_width=1,
-                specular=0.15,
+                lighting=True,
+                ambient=0.45,
+                diffuse=0.55,
+                specular=0.05,
+                specular_power=8,
                 smooth_shading=True,
                 name='domain'
             )
+            self._apply_domain_actor_style()
             if self._offscreen_mode and self._blit_widget is not None:
-                self._blit_widget._pickable_meshes = [domain.boundary]
+                self._blit_widget._pickable_meshes = [display_boundary or domain.boundary]
 
         # Update scale bar unit if domain has unit info
         if hasattr(domain, 'unit') and domain.unit:
@@ -1459,10 +1583,11 @@ class VTKWidget(QWidget):
 
     def clear(self):
         """Clear all visualizations except the domain."""
-        self.clear_points()
-        self.clear_directions()
-        self.clear_trees()
-        self.clear_connections()
+        with self.batch_render():
+            self.clear_points()
+            self.clear_directions()
+            self.clear_trees()
+            self.clear_connections()
 
     def reset_camera(self):
         """Reset the camera to show the full domain."""
@@ -1502,7 +1627,41 @@ class VTKWidget(QWidget):
                 self.domain_actor.GetProperty().SetEdgeVisibility(1 if self._domain_edges_visible else 0)
             except Exception:
                 pass
+        self._apply_domain_actor_style()
         self.request_render()
+
+    def _apply_domain_actor_style(self):
+        """Use soft lighting that preserves depth without faceted pseudo-edges."""
+        if self.domain_actor is None:
+            return
+        try:
+            prop = self.domain_actor.GetProperty()
+        except Exception:
+            return
+
+        try:
+            prop.SetInterpolationToPhong()
+        except Exception:
+            pass
+
+        try:
+            prop.LightingOn()
+        except Exception:
+            try:
+                prop.SetLighting(1)
+            except Exception:
+                pass
+
+        for setter, value in (
+            ("SetAmbient", 0.45),
+            ("SetDiffuse", 0.55),
+            ("SetSpecular", 0.05),
+            ("SetSpecularPower", 8.0),
+        ):
+            try:
+                getattr(prop, setter)(value)
+            except Exception:
+                pass
 
     def toggle_grid(self):
         """Toggle the visibility of the 3D grid."""
@@ -1566,45 +1725,46 @@ class VTKWidget(QWidget):
         if not self.plotter:
             return
 
-        self.clear_trees()
-        self.clear_connections()
+        with self.batch_render():
+            self.clear_trees()
+            self.clear_connections()
 
-        colors = ['red', 'blue', 'green', 'yellow', 'purple', 'orange', 'cyan', 'magenta']
+            colors = ['red', 'blue', 'green', 'yellow', 'purple', 'orange', 'cyan', 'magenta']
 
-        has_conn = getattr(forest, 'connections', None) is not None and \
-            getattr(forest.connections, 'tree_connections', None)
+            has_conn = getattr(forest, 'connections', None) is not None and \
+                getattr(forest.connections, 'tree_connections', None)
 
-        if has_conn:
-            for net_idx, tree_conn in enumerate(forest.connections.tree_connections):
-                # Trees within this network
-                for tree_idx, tree in enumerate(tree_conn.connected_network):
-                    color = colors[(net_idx + tree_idx) % len(colors)]
-                    self.add_tree(
-                        tree,
-                        color=color,
-                        label=f"forest_{net_idx}_{tree_idx}",
-                        group_id=("forest", net_idx, tree_idx),
-                    )
-                # Connection vessels between trees in this network
-                for tree_idx, vessel_list in enumerate(tree_conn.vessels):
-                    color = colors[tree_idx % len(colors)]
-                    for conn_idx, vessel in enumerate(vessel_list):
-                        self.add_connection_vessels(
-                            vessel,
+            if has_conn:
+                for net_idx, tree_conn in enumerate(forest.connections.tree_connections):
+                    # Trees within this network
+                    for tree_idx, tree in enumerate(tree_conn.connected_network):
+                        color = colors[(net_idx + tree_idx) % len(colors)]
+                        self.add_tree(
+                            tree,
                             color=color,
-                            label=f"conn_{net_idx}_{tree_idx}_{conn_idx}",
-                            group_id=("conn", net_idx, tree_idx, conn_idx),
+                            label=f"forest_{net_idx}_{tree_idx}",
+                            group_id=("forest", net_idx, tree_idx),
                         )
-        else:
-            for net_idx, network in enumerate(forest.networks):
-                for tree_idx, tree in enumerate(network):
-                    color = colors[(net_idx + tree_idx) % len(colors)]
-                    self.add_tree(
-                        tree,
-                        color=color,
-                        label=f"forest_{net_idx}_{tree_idx}",
-                        group_id=("forest", net_idx, tree_idx),
-                    )
+                    # Connection vessels between trees in this network
+                    for tree_idx, vessel_list in enumerate(tree_conn.vessels):
+                        color = colors[tree_idx % len(colors)]
+                        for conn_idx, vessel in enumerate(vessel_list):
+                            self.add_connection_vessels(
+                                vessel,
+                                color=color,
+                                label=f"conn_{net_idx}_{tree_idx}_{conn_idx}",
+                                group_id=("conn", net_idx, tree_idx, conn_idx),
+                            )
+            else:
+                for net_idx, network in enumerate(forest.networks):
+                    for tree_idx, tree in enumerate(network):
+                        color = colors[(net_idx + tree_idx) % len(colors)]
+                        self.add_tree(
+                            tree,
+                            color=color,
+                            label=f"forest_{net_idx}_{tree_idx}",
+                            group_id=("forest", net_idx, tree_idx),
+                        )
 
     def _on_point_picked(self, point):
         """

--- a/test/test_gui_vtk_platform_guard.py
+++ b/test/test_gui_vtk_platform_guard.py
@@ -11,6 +11,21 @@ import svv.visualize.gui.vtk_widget as vtk_widget_mod
 from svv.visualize.gui.vtk_widget import VTKWidget
 
 
+class _RenderCountingPlotter:
+    def __init__(self):
+        self.render_count = 0
+
+    def render(self):
+        self.render_count += 1
+
+
+def _dispose_widget(app, widget):
+    widget._render_timer.stop()
+    widget.plotter = None
+    widget.deleteLater()
+    app.processEvents()
+
+
 def test_vtk_widget_disables_vtk_for_offscreen_qt(monkeypatch):
     monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
     monkeypatch.delenv("SVV_GUI_DISABLE_VTK", raising=False)
@@ -74,3 +89,46 @@ def test_build_vessel_tube_mesh_batches_segments():
     assert mesh is not None
     assert mesh.n_points > 0
     assert mesh.n_cells > 0
+
+
+def test_request_render_coalesces_pending_requests(monkeypatch):
+    monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    widget = VTKWidget()
+    plotter = _RenderCountingPlotter()
+    widget.plotter = plotter
+
+    widget.request_render()
+    widget.request_render()
+    widget.request_render(delay_ms=10)
+
+    assert plotter.render_count == 0
+    assert widget._render_timer.isActive()
+
+    app.processEvents()
+
+    assert plotter.render_count == 1
+    _dispose_widget(app, widget)
+
+
+def test_batch_render_defers_nested_requests(monkeypatch):
+    monkeypatch.setenv("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance() or QApplication([])
+    widget = VTKWidget()
+    plotter = _RenderCountingPlotter()
+    widget.plotter = plotter
+
+    with widget.batch_render():
+        widget.request_render()
+        with widget.batch_render():
+            widget.request_render(immediate=True)
+        assert plotter.render_count == 0
+        assert not widget._render_timer.isActive()
+
+    assert plotter.render_count == 0
+    assert widget._render_timer.isActive()
+
+    app.processEvents()
+
+    assert plotter.render_count == 1
+    _dispose_widget(app, widget)


### PR DESCRIPTION
<!-- Give your pull request (PR) a descriptive name -->

## Current situation

Closes #85.

Repeated scene mutations currently trigger one VTK render per actor or style update, which makes dense tree, forest, and point refreshes sluggish. Generation and point-selection controls also outgrow narrow dock layouts, while completed actions rely on blocking dialogs.

This change:

- coalesces viewport render requests with a single-shot timer and a nested batch-render context;
- batches tree, forest, connection, and point refreshes;
- uses bounded combo boxes, wrapping forms, grid layouts, and collapsible forest and advanced sections;
- reports completed actions through status and viewport messages, creates the Solution Inspector only when needed, and gives domain surfaces smoother lighting with edges hidden by default; and
- adds headless regression coverage for repeated and nested render requests.

## Release Notes

- Improved GUI responsiveness during dense scene updates.
- Improved Generation and Start Points panel behavior in narrow dock layouts.
- Replaced blocking success dialogs with transient status and viewport feedback.
- Updated default domain presentation with smooth shading and hidden mesh edges.

## Documentation

No documentation changes are required. Existing labels and tooltips continue to describe the affected controls.

## Testing

- `QT_QPA_PLATFORM=offscreen SVV_GUI_DISABLE_VTK=1 SVV_TELEMETRY_DISABLED=1 pytest -q test/test_gui_vtk_platform_guard.py test/test_gui_activation_policy.py test/test_zerod_gui_pipeline.py` — 22 passed.
- `python -m py_compile svv/visualize/gui/main_window.py svv/visualize/gui/parameter_panel.py svv/visualize/gui/point_selector.py svv/visualize/gui/vtk_widget.py` — passed.
- A live embedded VTK window was not exercised on macOS, Linux, or Windows in this headless environment.

## Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).