### PR TITLE
Add monthly PyPI downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 
 [![Version](https://img.shields.io/pypi/v/svv.svg?logo=pypi&label=PyPI%20version)](https://pypi.org/project/svv/)
+[![PyPI downloads](https://img.shields.io/pypi/dm/svv.svg?logo=pypi&label=downloads%2Fmonth)](https://pypistats.org/packages/svv)
 ![Platform](https://img.shields.io/badge/platform-macOS%20|%20linux%20|%20windows-blue)
 ![Latest Release](https://img.shields.io/github/v/release/SimVascular/svVascularize?label=latest)
 [![codecov](https://codecov.io/github/SimVascular/svVascularize/graph/badge.svg)](https://codecov.io/github/SimVascular/svVascularize)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # svVascularize
 
 
-[![Version](https://img.shields.io/pypi/v/svv.svg?logo=pypi&label=PyPI%20version)](https:://pypi.org/project/svv/)
+[![Version](https://img.shields.io/pypi/v/svv.svg?logo=pypi&label=PyPI%20version)](https://pypi.org/project/svv/)
 ![Platform](https://img.shields.io/badge/platform-macOS%20|%20linux%20|%20windows-blue)
 ![Latest Release](https://img.shields.io/github/v/release/SimVascular/svVascularize?label=latest)
 [![codecov](https://codecov.io/github/SimVascular/svVascularize/graph/badge.svg)](https://codecov.io/github/SimVascular/svVascularize)


### PR DESCRIPTION
## Current situation

Closes #95.

The README links to the `svv` package and displays its current PyPI version, but it does not expose monthly download activity. The existing PyPI version badge also contains a malformed destination URL.

This change adds a dynamically generated monthly-download badge beside the version badge and corrects the existing PyPI link. No workflow or generated badge data is added to the repository.

## Release Notes

- Display the monthly PyPI download count for `svv` in the README badge row.
- Correct the destination URL for the existing PyPI version badge.

## Documentation

The README badge row is updated directly. No additional documentation changes are needed.

## Testing

- Confirmed the Shields.io badge endpoint returns HTTP 200 with an SVG response and uses the `dm` monthly-download route for `svv`.
- Confirmed the PyPI Stats destination loads and reports monthly download data for `svv`.
- Confirmed the corrected PyPI package link loads successfully.
- Rendered the README through GitHub's Markdown API and confirmed the badge is emitted as a linked image with the expected alt text and canonical source URL.
- Ran `git diff --check upstream/main...HEAD`.

During validation, Shields.io displayed its temporary upstream rate-limit fallback instead of the numeric count. PyPI Stats remained available and reported the monthly value; the badge uses the documented dynamic endpoint and requires no repository-side updates when the service refreshes.

## Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
