### PR TITLE
Fix VTU domain boundary handling

### DIFF
--- a/svv/domain/domain.py
+++ b/svv/domain/domain.py
@@ -158,8 +158,11 @@ class Domain(object):
                 self.n = self.points.shape[0]
                 self.d = self.points.shape[1]
             elif 'pyvista' in str(args[0].__class__):
-                points, normals, n, d = read(args[0], **kwargs)
-                self.original_boundary = args[0]
+                boundary = args[0]
+                if isinstance(boundary, pv.UnstructuredGrid):
+                    boundary = boundary.extract_surface()
+                points, normals, n, d = read(boundary, **kwargs)
+                self.original_boundary = boundary
                 self.points = points
                 self.normals = normals
                 self.n = n


### PR DESCRIPTION
<!-- Proposed title: Fix VTU domain boundary handling -->
<!-- Template: https://github.com/SimVascular/.github/blob/main/.github/pull_request_template.md -->

## Current situation

Fixes #77.

The GUI accepts `.vtu` files as domain inputs, but PyVista reads them as
`UnstructuredGrid` objects. Domain initialization used the extracted surface to
compute points and normals while retaining the original `UnstructuredGrid` as
`original_boundary`. Boundary construction later accessed the PolyData-only
`is_all_triangles` property, causing domain building to fail.

This change extracts and retains a `PolyData` surface when the supplied mesh is
an `UnstructuredGrid`, keeping the stored boundary consistent with downstream
boundary operations.

## Release Notes

- Fix loading VTU volume meshes as domain inputs by retaining their extracted
  surface for boundary construction.

## Documentation

No documentation changes are required. This corrects the existing documented
and GUI-exposed VTU input behavior without changing the public interface.

## Testing

- Constructed a tetrahedral `UnstructuredGrid` and verified that `Domain`
  retains a `PolyData` boundary.
- Exercised `Domain.get_boundary()` and confirmed that it produces a triangular
  boundary without the `is_all_triangles` error.
- Compiled `svv/domain/domain.py` successfully.

## Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
