### PR TITLE
Prevent degenerate surface triangles from reaching MMGS

### DIFF
--- a/svv/tree/export/export_solid.py
+++ b/svv/tree/export/export_solid.py
@@ -818,7 +818,7 @@ def union_tubes(tubes, lines, cap_resolution=40):
                 total_steps=total_steps,
                 tube_index=i,
             )
-    model.cell_data['hsize'] = 0
+    model.cell_data['hsize'] = numpy.zeros(model.n_cells, dtype=float)
     model.cell_data['hsize'][0] = hsize
     return model
 
@@ -1061,7 +1061,7 @@ def union_tubes_balanced(tubes, lines, cap_resolution=40, method='centerline', e
     #fix.repair()
     #model = fix.mesh
     if hsize is not None:
-        model.cell_data['hsize'] = 0
+        model.cell_data['hsize'] = _np.zeros(model.n_cells, dtype=float)
         model.cell_data['hsize'][0] = hsize
     return model
 

--- a/svv/tree/export/export_solid.py
+++ b/svv/tree/export/export_solid.py
@@ -7,7 +7,11 @@ import pymeshfix
 from tqdm import trange, tqdm
 from scipy.interpolate import splprep, splev
 from scipy.spatial import cKDTree
-from svv.utils.remeshing.remesh import remesh_surface, write_medit_sol
+from svv.utils.remeshing.remesh import (
+    _prepare_surface_for_mmgs,
+    remesh_surface,
+    write_medit_sol,
+)
 from svv.domain.routines.boolean import boolean
 
 
@@ -680,6 +684,102 @@ def generate_tubes_parallel(polylines, hsize=None, processes=None, chunksize=1, 
         tubes.append(tube)
     return tubes
 
+def _surface_topology(surface):
+    """Return manifold and open-edge state for a polygonal surface."""
+    try:
+        manifold = bool(surface.is_manifold)
+        open_edges = int(surface.n_open_edges)
+    except Exception as exc:
+        raise RuntimeError("Unable to inspect the tube-union surface topology.") from exc
+    return manifold, open_edges
+
+
+def _prepare_watertight_union_surface(surface, *, step, total_steps):
+    """Sanitize and, when needed, repair a watertight union intermediate."""
+    context = f"Tube union step {step}/{total_steps}"
+    try:
+        prepared, _, diagnostics = _prepare_surface_for_mmgs(surface, verbosity=1)
+    except Exception as exc:
+        raise RuntimeError(f"{context} produced an invalid surface: {exc}") from exc
+
+    manifold, open_edges = _surface_topology(prepared)
+    repaired = False
+    removed_triangles = diagnostics["invalid_triangle_count"]
+    invalid_indices = diagnostics["invalid_triangle_indices"][:10]
+
+    if not manifold or open_edges != 0:
+        repaired = True
+        before_points = prepared.n_points
+        before_triangles = prepared.n_cells
+        try:
+            fix = pymeshfix.MeshFix(prepared)
+            fix.repair(verbose=False)
+            prepared, _, repair_diagnostics = _prepare_surface_for_mmgs(
+                fix.mesh, verbosity=1
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"{context} could not repair its boolean result "
+                f"(points={before_points}, triangles={before_triangles}, "
+                f"removed_invalid_triangles={removed_triangles}, "
+                f"invalid_triangle_indices={invalid_indices}, "
+                f"manifold={manifold}, open_edges={open_edges})."
+            ) from exc
+        removed_triangles += repair_diagnostics["invalid_triangle_count"]
+
+    manifold, open_edges = _surface_topology(prepared)
+    if prepared.n_points == 0 or prepared.n_cells == 0 or not manifold or open_edges != 0:
+        raise RuntimeError(
+            f"{context} did not produce a watertight surface "
+            f"(points={prepared.n_points}, triangles={prepared.n_cells}, "
+            f"removed_invalid_triangles={removed_triangles}, repaired={repaired}, "
+            f"manifold={manifold}, open_edges={open_edges})."
+        )
+
+    return prepared, {
+        "removed_invalid_triangles": removed_triangles,
+        "invalid_triangle_indices": invalid_indices,
+        "repaired": repaired,
+    }
+
+
+def _union_and_remesh_tube(left, right, *, hsize, step, total_steps, tube_index):
+    """Perform one diagnosed, watertight boolean-union and remeshing step."""
+    context = f"Tube union step {step}/{total_steps} (adding tube index {tube_index})"
+    try:
+        model = boolean(left, right, operation='union', fix_mesh=False)
+    except Exception as exc:
+        raise RuntimeError(f"{context} failed during the boolean operation.") from exc
+
+    model, preparation = _prepare_watertight_union_surface(
+        model, step=step, total_steps=total_steps
+    )
+    model = model.compute_normals(auto_orient_normals=True)
+
+    try:
+        model = remesh_surface(model, hsiz=hsize)
+    except Exception as exc:
+        manifold, open_edges = _surface_topology(model)
+        raise RuntimeError(
+            f"{context} failed during surface remeshing "
+            f"(points={model.n_points}, triangles={model.n_cells}, hsiz={hsize:.15g}, "
+            f"removed_invalid_triangles={preparation['removed_invalid_triangles']}, "
+            f"invalid_triangle_indices={preparation['invalid_triangle_indices']}, "
+            f"repaired={preparation['repaired']}, manifold={manifold}, "
+            f"open_edges={open_edges})."
+        ) from exc
+
+    model = model.compute_normals(auto_orient_normals=True)
+    manifold, open_edges = _surface_topology(model)
+    if model.n_points == 0 or model.n_cells == 0 or not manifold or open_edges != 0:
+        raise RuntimeError(
+            f"{context} remeshing returned a non-watertight surface "
+            f"(points={model.n_points}, triangles={model.n_cells}, hsiz={hsize:.15g}, "
+            f"manifold={manifold}, open_edges={open_edges})."
+        )
+    return model
+
+
 def union_tubes(tubes, lines, cap_resolution=40):
     """
     This function performs iterative boolean union operations on a list of Pyvista polydata surface
@@ -695,18 +795,29 @@ def union_tubes(tubes, lines, cap_resolution=40):
     union : pyvista.PolyData
         The result of the boolean union operation.
     """
-    model = boolean(tubes[0], tubes[1], operation='union')
-    model = model.compute_normals(auto_orient_normals=True)
+    if len(tubes) < 2:
+        raise ValueError("union_tubes requires at least two tube surfaces")
+    if len(lines) != len(tubes):
+        raise ValueError("lines and tubes must have the same length")
+    if cap_resolution <= 0:
+        raise ValueError("cap_resolution must be positive")
+
+    total_steps = len(tubes) - 1
     hsize = (min(min(lines[0]['radius']), min(lines[1]['radius']))*2*numpy.pi)/cap_resolution
-    model = remesh_surface(model, hsiz=hsize)
-    model = model.compute_normals(auto_orient_normals=True)
+    model = _union_and_remesh_tube(
+        tubes[0], tubes[1], hsize=hsize, step=1, total_steps=total_steps, tube_index=1
+    )
     if len(tubes) > 2:
         for i in range(2, len(tubes)):
-            model = boolean(model, tubes[i], operation='union')
-            model = model.compute_normals(auto_orient_normals=True)
             hsize = min(hsize, (min(lines[i]['radius'])*2*numpy.pi)/cap_resolution)
-            model = remesh_surface(model, hsiz=hsize)
-            model = model.compute_normals(auto_orient_normals=True)
+            model = _union_and_remesh_tube(
+                model,
+                tubes[i],
+                hsize=hsize,
+                step=i,
+                total_steps=total_steps,
+                tube_index=i,
+            )
     model.cell_data['hsize'] = 0
     model.cell_data['hsize'][0] = hsize
     return model
@@ -731,22 +842,33 @@ def build_watertight_solid(tree, cap_resolution=40):
     lines = generate_polylines(xyz, r)
     tubes = generate_tubes(lines)
     model = union_tubes(tubes, lines, cap_resolution=cap_resolution)
+    if 'hsize' not in model.cell_data or model.n_cells == 0:
+        raise RuntimeError("Watertight tube union did not retain its target surface size.")
+    hsize = float(model.cell_data['hsize'][0])
     #tubes = generate_tubes_parallel(lines, radius_based=True)
     #model = union_tubes_balanced(tubes, lines, cap_resolution=cap_resolution)
     # Remove poor quality elements and repair the mesh.
     cell_quality = model.compute_cell_quality(quality_measure='scaled_jacobian')
-    keep = cell_quality.cell_data["CellQuality"] > 0.1
+    quality_values = numpy.asarray(cell_quality.cell_data["CellQuality"])
+    keep = numpy.isfinite(quality_values) & (quality_values > 0.1)
     if not numpy.all(keep):
-        print("Removing poor quality elements from the mesh.")
-        #keep = numpy.argwhere(keep).flatten()
-        #non_manifold_model = model.extract_cells(keep)
-        #non_manifold_model = non_manifold_model.extract_surface()
-        fix = pymeshfix.MeshFix(model) # non_manifold_model)
+        print("Repairing poor quality elements in the mesh.")
+        fix = pymeshfix.MeshFix(model)
         fix.repair(verbose=True)
-        hsize = model.cell_data["hsize"][0] #hsize
-        model = fix.mesh.compute_normals(auto_orient_normals=True)
-        #model.hsize = hsize
-        model.cell_data['hsize'] = 0
+        model, _ = _prepare_watertight_union_surface(
+            fix.mesh,
+            step=max(len(tubes) - 1, 1),
+            total_steps=max(len(tubes) - 1, 1),
+        )
+        model = model.compute_normals(auto_orient_normals=True)
+    manifold, open_edges = _surface_topology(model)
+    if not manifold or open_edges != 0:
+        raise RuntimeError(
+            "Final vascular solid is not watertight "
+            f"(points={model.n_points}, triangles={model.n_cells}, "
+            f"manifold={manifold}, open_edges={open_edges})."
+        )
+    model.cell_data['hsize'] = numpy.zeros(model.n_cells)
     model.cell_data['hsize'][0] = hsize
     return model
 

--- a/svv/utils/remeshing/remesh.py
+++ b/svv/utils/remeshing/remesh.py
@@ -16,6 +16,234 @@ from typing import Sequence, Optional
 
 from .mmg import run_mmg
 
+
+# MMG rejects an input mesh when its normalized minimum element quality is
+# below MMG5_NULKAL.  Keeping the same conservative floor here prevents
+# mathematically degenerate triangles from reaching the executable without
+# discarding merely low-quality triangles that MMG is intended to improve.
+_MMG_MIN_TRIANGLE_QUALITY = 1.0e-30
+
+
+def _copy_polygon_surface(surface):
+    """Return a deep, polygon-only copy while preserving associated data."""
+    points = numpy.asarray(surface.points)
+    faces = numpy.asarray(surface.faces)
+    copied = pv.PolyData(numpy.array(points, copy=True), numpy.array(faces, copy=True))
+
+    for name in surface.point_data.keys():
+        copied.point_data[name] = numpy.array(surface.point_data[name], copy=True)
+
+    polygon_count = copied.n_cells
+    polygon_start = int(surface.GetNumberOfVerts() + surface.GetNumberOfLines())
+    for name in surface.cell_data.keys():
+        values = numpy.asarray(surface.cell_data[name])
+        if values.shape[0] != surface.n_cells:
+            raise ValueError(
+                f"Cell-data array {name!r} has {values.shape[0]} values for "
+                f"{surface.n_cells} cells."
+            )
+        copied.cell_data[name] = numpy.array(
+            values[polygon_start:polygon_start + polygon_count], copy=True
+        )
+
+    for name in surface.field_data.keys():
+        copied.field_data[name] = numpy.array(surface.field_data[name], copy=True)
+
+    return copied
+
+
+def _triangle_qualities(points, triangles):
+    """Compute the dimensionless isotropic triangle quality used by MMGS."""
+    triangle_points = points[triangles]
+    ab = triangle_points[:, 1] - triangle_points[:, 0]
+    ac = triangle_points[:, 2] - triangle_points[:, 0]
+    bc = triangle_points[:, 2] - triangle_points[:, 1]
+    with numpy.errstate(over="ignore", invalid="ignore", divide="ignore"):
+        denominator = (
+            numpy.einsum("ij,ij->i", ab, ab)
+            + numpy.einsum("ij,ij->i", ac, ac)
+            + numpy.einsum("ij,ij->i", bc, bc)
+        )
+        quality = numpy.linalg.norm(numpy.cross(ab, ac), axis=1) / denominator
+    return quality, denominator
+
+
+def _normalize_required_triangles(required_triangles, triangle_count):
+    """Validate MMG's one-based required-triangle indices."""
+    if required_triangles is None:
+        return None
+
+    try:
+        values = list(required_triangles)
+    except TypeError as exc:
+        raise ValueError("required_triangles must be a one-dimensional sequence of integers") from exc
+
+    normalized = []
+    for value in values:
+        if isinstance(value, (bool, numpy.bool_)) or not isinstance(value, (int, numpy.integer)):
+            raise ValueError("required_triangles must contain only integer indices")
+        index = int(value)
+        if index < 1 or index > triangle_count:
+            raise ValueError(
+                f"required triangle index {index} is outside the valid one-based range "
+                f"[1, {triangle_count}]"
+            )
+        normalized.append(index)
+    return normalized
+
+
+def _prepare_surface_for_mmgs(
+        surface, required_triangles=None, verbosity=1,
+        quality_threshold=_MMG_MIN_TRIANGLE_QUALITY):
+    """Validate and remove triangles that MMGS cannot accept.
+
+    Point ordering and point count are deliberately preserved so an existing
+    per-vertex Medit solution remains aligned with the surface.  Returned
+    required-triangle indices use MMG's one-based convention.
+    """
+    if not hasattr(surface, "points") or not hasattr(surface, "faces"):
+        raise TypeError("remesh_surface requires a polygonal surface with points and faces")
+    if quality_threshold < 0.0 or not numpy.isfinite(quality_threshold):
+        raise ValueError("quality_threshold must be a finite, non-negative value")
+
+    mesh = _copy_polygon_surface(surface)
+    if mesh.n_points == 0 or mesh.n_cells == 0:
+        raise ValueError(
+            f"Cannot remesh an empty surface (points={mesh.n_points}, triangles=0)."
+        )
+
+    points = numpy.asarray(mesh.points, dtype=float)
+    original_points = numpy.array(points, copy=True)
+    finite_points = numpy.all(numpy.isfinite(points), axis=1)
+    if not numpy.all(finite_points):
+        invalid_points = (numpy.flatnonzero(~finite_points) + 1).tolist()
+        preview = invalid_points[:10]
+        suffix = "..." if len(invalid_points) > len(preview) else ""
+        raise ValueError(
+            f"Surface contains {len(invalid_points)} point(s) with non-finite coordinates; "
+            f"one-based point indices: {preview}{suffix}."
+        )
+
+    if required_triangles is not None and not mesh.is_all_triangles:
+        raise ValueError(
+            "remesh_surface(required_triangles=...) requires the input surface to be all triangles "
+            "(so indices match). Triangulate the mesh first."
+        )
+    if not mesh.is_all_triangles:
+        mesh = mesh.triangulate(inplace=False)
+
+    if mesh.n_cells == 0 or not mesh.is_all_triangles:
+        raise ValueError("Surface triangulation did not produce any triangular faces.")
+    if (
+            mesh.n_points != original_points.shape[0]
+            or not numpy.array_equal(numpy.asarray(mesh.points), original_points)):
+        raise ValueError(
+            "Surface triangulation changed point ordering, which would invalidate per-vertex sizing data."
+        )
+    points = numpy.asarray(mesh.points, dtype=float)
+
+    face_records = numpy.asarray(mesh.faces).reshape(-1, 4)
+    triangles = face_records[:, 1:].astype(numpy.int64, copy=False)
+    triangle_count = triangles.shape[0]
+    normalized_required = _normalize_required_triangles(required_triangles, triangle_count)
+
+    if numpy.any(triangles < 0) or numpy.any(triangles >= mesh.n_points):
+        raise ValueError("Surface contains a triangle with an out-of-range point index.")
+
+    repeated_indices = (
+        (triangles[:, 0] == triangles[:, 1])
+        | (triangles[:, 0] == triangles[:, 2])
+        | (triangles[:, 1] == triangles[:, 2])
+    )
+    quality, denominator = _triangle_qualities(points, triangles)
+
+    valid = (
+        ~repeated_indices
+        & numpy.isfinite(quality)
+        & (denominator > 0.0)
+        & (quality > quality_threshold)
+    )
+    invalid_zero_based = numpy.flatnonzero(~valid)
+    invalid_one_based = (invalid_zero_based + 1).tolist()
+
+    if normalized_required is not None:
+        invalid_required = [index for index in normalized_required if not valid[index - 1]]
+        if invalid_required:
+            raise ValueError(
+                "Required triangle(s) are degenerate and cannot be passed to MMGS: "
+                f"{invalid_required}."
+            )
+
+    finite_quality = quality[numpy.isfinite(quality)]
+    minimum_quality = float(numpy.min(finite_quality)) if finite_quality.size else None
+
+    if invalid_zero_based.size:
+        retained_triangles = triangles[valid]
+        if retained_triangles.shape[0] == 0:
+            raise ValueError(
+                f"Surface has no MMGS-compatible triangles; rejected all {triangle_count} faces."
+            )
+
+        vtk_faces = numpy.hstack((
+            numpy.full((retained_triangles.shape[0], 1), 3, dtype=numpy.int64),
+            retained_triangles,
+        )).ravel()
+        sanitized = pv.PolyData(numpy.array(mesh.points, copy=True), vtk_faces)
+        for name in mesh.point_data.keys():
+            sanitized.point_data[name] = numpy.array(mesh.point_data[name], copy=True)
+        for name in mesh.cell_data.keys():
+            sanitized.cell_data[name] = numpy.array(mesh.cell_data[name][valid], copy=True)
+        for name in mesh.field_data.keys():
+            sanitized.field_data[name] = numpy.array(mesh.field_data[name], copy=True)
+        mesh = sanitized
+
+        if normalized_required is not None:
+            new_indices = numpy.cumsum(valid, dtype=numpy.int64)
+            normalized_required = [int(new_indices[index - 1]) for index in normalized_required]
+
+        if verbosity is not None and verbosity > 0:
+            preview = invalid_one_based[:10]
+            suffix = "..." if len(invalid_one_based) > len(preview) else ""
+            print(
+                f"Removed {len(invalid_one_based)} MMGS-incompatible triangle(s); "
+                f"one-based indices: {preview}{suffix}."
+            )
+
+    retained_face_records = numpy.asarray(mesh.faces).reshape(-1, 4)
+    retained_triangles = retained_face_records[:, 1:].astype(numpy.int64, copy=False)
+    retained_quality, _ = _triangle_qualities(
+        numpy.asarray(mesh.points, dtype=float), retained_triangles
+    )
+    if (
+            not numpy.all(numpy.isfinite(retained_quality))
+            or numpy.any(retained_quality <= quality_threshold)):
+        raise ValueError("Surface still contains an MMGS-incompatible triangle after sanitization.")
+
+    diagnostics = {
+        "original_point_count": int(points.shape[0]),
+        "original_triangle_count": int(triangle_count),
+        "triangle_count": int(mesh.n_cells),
+        "invalid_triangle_count": int(invalid_zero_based.size),
+        "invalid_triangle_indices": invalid_one_based,
+        "minimum_quality": minimum_quality,
+        "sanitized_minimum_quality": float(numpy.min(retained_quality)),
+        "quality_threshold": float(quality_threshold),
+    }
+    return mesh, normalized_required, diagnostics
+
+
+def _surface_topology_diagnostics(surface):
+    """Return best-effort topology values for a remeshing error message."""
+    try:
+        manifold = bool(surface.is_manifold)
+    except Exception:
+        manifold = None
+    try:
+        open_edges = int(surface.n_open_edges)
+    except Exception:
+        open_edges = None
+    return manifold, open_edges
+
 def remesh_surface_2d(boundary, autofix=False, ar=None, hausd=None, hgrad=None, verbosity=1,
                    hmax=None, hmin=None, hsiz=None, noinsert=None, nomove=None, nosurf=True,
                    noswap=None, nr=None, optim=None, rn=None, nsd=None):
@@ -313,8 +541,9 @@ def remesh_surface(pv_polydata_object, autofix=True, ar=None, hausd=None, hgrad=
         The 3D surface mesh to be remeshed.
 
     autofix : bool, optional
-        If True, attempts to automatically fix non-manifold issues in the remeshed surface using pymeshfix.
-        Default is True.
+        If True, attempts to fix non-manifold issues in the MMGS output using
+        pymeshfix. Invalid input triangles are removed before MMGS regardless
+        of this setting. Default is True.
 
     ar : float, optional
         Anisotropy ratio. See MMGS documentation for details.
@@ -359,7 +588,9 @@ def remesh_surface(pv_polydata_object, autofix=True, ar=None, hausd=None, hgrad=
         Removes nonmanifold elements. See MMGS documentation.
 
     required_triangles : list of int, optional
-        List of triangle indices that are required and should not be modified during remeshing.
+        One-based triangle indices that are required and should not be modified
+        during remeshing. Indices are remapped if earlier invalid faces are
+        removed. An invalid required face raises ``ValueError``.
 
     Returns
     -------
@@ -368,13 +599,19 @@ def remesh_surface(pv_polydata_object, autofix=True, ar=None, hausd=None, hgrad=
 
     Raises
     ------
+    ValueError
+        If the input is empty, contains non-finite points, has no
+        MMGS-compatible triangles, or protects an invalid triangle.
     NotImplementedError
         If the remeshing process does not produce triangular faces.
+    RuntimeError
+        If MMGS rejects the sanitized surface.
 
     Notes
     -----
-    This function utilizes the MMGS executable to perform remeshing. The MMG executables must be present in
-    the appropriate directory for your operating system.
+    This function removes only triangles that fail MMGS's minimum input-quality
+    requirement before invoking the MMGS executable. The MMG executables must
+    be present in the appropriate directory for your operating system.
 
     References
     ----------
@@ -409,14 +646,11 @@ def remesh_surface(pv_polydata_object, autofix=True, ar=None, hausd=None, hgrad=
         boundary = pv.Circle()
         remeshed = remesh_surface_2d(boundary, hmax=0.2, hmin=0.05, hausd=0.01, verbosity=3)
     """
-    _mesh_ = pv.PolyData(pv_polydata_object.points, pv_polydata_object.faces)
-    if required_triangles is not None and (not _mesh_.is_all_triangles):
-        raise ValueError(
-            "remesh_surface(required_triangles=...) requires the input surface to be all triangles "
-            "(so indices match). Triangulate the mesh first."
-        )
-    if not _mesh_.is_all_triangles:
-        _mesh_ = _mesh_.triangulate(inplace=False)
+    _mesh_, required_triangles, input_diagnostics = _prepare_surface_for_mmgs(
+        pv_polydata_object,
+        required_triangles=required_triangles,
+        verbosity=verbosity,
+    )
 
     # Run MMG in an isolated temp directory to avoid permission issues and temp-file collisions.
     tmp_root = None
@@ -474,10 +708,23 @@ def remesh_surface(pv_polydata_object, autofix=True, ar=None, hausd=None, hgrad=
         if rn is not None:
             args.extend(["-rn", str(rn)])
 
-        if verbosity == 0:
-            run_mmg("mmgs", args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=tmpdir)
-        else:
-            run_mmg("mmgs", args, cwd=tmpdir)
+        try:
+            if verbosity == 0:
+                run_mmg("mmgs", args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, cwd=tmpdir)
+            else:
+                run_mmg("mmgs", args, cwd=tmpdir)
+        except subprocess.CalledProcessError as exc:
+            manifold, open_edges = _surface_topology_diagnostics(_mesh_)
+            invalid_indices = input_diagnostics["invalid_triangle_indices"][:10]
+            raise RuntimeError(
+                "MMGS surface remeshing failed after input sanitization "
+                f"(points={_mesh_.n_points}, triangles={_mesh_.n_cells}, "
+                f"removed_invalid_triangles={input_diagnostics['invalid_triangle_count']}, "
+                f"invalid_triangle_indices={invalid_indices}, "
+                f"minimum_retained_quality={input_diagnostics['sanitized_minimum_quality']:.6e}, "
+                f"manifold={manifold}, open_edges={open_edges}, args={args!r}, "
+                f"returncode={exc.returncode})."
+            ) from exc
         mmg_succeeded = True
 
         out_mesh_path = tmpdir_path / "tmp.o.mesh"
@@ -497,9 +744,7 @@ def remesh_surface(pv_polydata_object, autofix=True, ar=None, hausd=None, hgrad=
         if autofix:
             if not remeshed_surface.is_manifold:
                 fix = pymeshfix.MeshFix(remeshed_surface)
-                if verbosity == 0:
-                    fix.repair(verbose=False)
-                fix.repair(verbose=True)
+                fix.repair(verbose=verbosity != 0)
                 remeshed_surface = fix.mesh
 
     # Clean up sizing file if provided (historical behavior)


### PR DESCRIPTION
<!--
Proposed title: Prevent degenerate surface triangles from reaching MMGS
Proposed author: Zachary Sexton <zsexton@stanford.edu>
Base branch: main
Head branch: issue-48
-->

<!-- Give your pull request (PR) a descriptive name -->

## Current situation

Closes [#48](https://github.com/SimVascular/svVascularize/issues/48).

Iterative boolean unions used to construct watertight vascular solids can produce repeated-index, collinear, or otherwise zero-quality triangles. `remesh_surface()` previously wrote these faces directly to its Medit input, causing MMGS to stop during its minimum-quality check before post-remeshing repair could run.

This change:

- Sanitizes a copied, triangulated surface immediately before MMGS and removes only faces at or below MMG's null-quality threshold.
- Preserves caller-owned data, point ordering, per-vertex sizing alignment, and safely remaps one-based required-triangle indices.
- Rejects invalid protected faces, non-finite coordinates, empty inputs, and surfaces with no valid triangles using actionable errors.
- Validates every vascular tube-union intermediate, conditionally repairs topology when watertightness is required, and reports the failing union step and mesh state.
- Preserves the floating-point tube-union target mesh size instead of allowing integer cell-data allocation to truncate it.

## Release Notes 

- Prevent surface-remeshing failures when boolean operations produce degenerate triangles that MMGS cannot accept.
- Improve watertight vascular-solid validation and failure diagnostics without changing the public API.

## Documentation

The `remesh_surface()` documentation now describes input sanitization, one-based required-triangle handling, preserved sizing alignment, and the validation errors callers may receive. There are no public API changes requiring additional migration documentation.

## Testing

- Temporary native MMGS 5.8.0 verification covered repeated-index and distinct-collinear triangles, unchanged valid surfaces, mesh-data preservation, required-triangle remapping and rejection, and `in.sol` point alignment.
- An overlapping-tube boolean result completed sanitization and native remeshing with a manifold, closed output.
- The exact STL and serialized tree referenced by the reporter were unavailable, so the original artifact could not be reproduced exactly.

## Code of Conduct & Contributing Guidelines 

- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
