### PR TITLE
Expose a discoverable public API from the svv package namespace

### DIFF
--- a/.github/scripts/basic_smoke_test.py
+++ b/.github/scripts/basic_smoke_test.py
@@ -156,10 +156,7 @@ def _smoke_gui(timeout_s: int = 45) -> None:
 def main() -> None:
     import pyvista as pv
 
-    from svv.domain.domain import Domain
-    from svv.forest.forest import Forest
-    from svv.tree.tree import Tree
-    from svv.simulation.simulation import Simulation
+    from svv import Domain, Forest, Simulation, Tree
     from svv.utils.remeshing.mmg import get_mmg_candidates, get_mmg_exe
     from svv.utils.solvers.solver_0d import get_solver_0d_candidates, get_solver_0d_exe
     from svv.utils.remeshing.remesh import remesh_surface

--- a/README.md
+++ b/README.md
@@ -50,3 +50,18 @@ python -m pip install --force-reinstall "numpy>=2.1" svv
 
 On clusters / HPC systems (for example Stanford Sherlock), use a recent Python (3.9–3.13) and `pip`, and install into a
 clean virtual environment or user site-packages.
+
+## Basic usage
+
+Import the primary classes from the root package and supporting types from
+their public subpackages:
+
+```python
+from svv import Domain, Forest, Simulation, Tree
+from svv.domain import Patch
+from svv.tree import TreeParameters, UnitSystem
+```
+
+`dir(svv)` lists the curated root API. Explicit imports are recommended for
+application code, and existing deep import paths remain supported for
+compatibility.

--- a/docs/api/domain.html
+++ b/docs/api/domain.html
@@ -68,7 +68,7 @@
             <h2>Quick Example</h2>
             <pre data-copy><code class="language-python">import numpy as np
 import pyvista as pv
-from svv.domain.domain import Domain
+from svv.domain import Domain
 
 # Create domain from PyVista mesh
 mesh = pv.read('vessel_geometry.stl')
@@ -491,7 +491,7 @@ boundary_points = domain.get_boundary_points(n=500)</code></pre>
 
                     <div class="api-example">
                         <h4>Save/Load Example</h4>
-                        <pre data-copy><code class="language-python">from svv.domain.domain import Domain
+                        <pre data-copy><code class="language-python">from svv.domain import Domain
 import pyvista as pv
 
 # Create domain from a complex mesh
@@ -552,7 +552,7 @@ difference_domain = domain1 - domain2</code></pre>
                     <div class="api-example">
                         <h3>Creating a Domain from STL File</h3>
                         <pre data-copy><code class="language-python">import pyvista as pv
-from svv.domain.domain import Domain
+from svv.domain import Domain
 
 # Load STL file
 mesh = pv.read('vessel.stl')
@@ -574,7 +574,7 @@ print(f"Convexity: {domain.convexity:.3f}")</code></pre>
                     <div class="api-example">
                         <h3>Customized Patch Allocation</h3>
                         <pre data-copy><code class="language-python">import pyvista as pv
-from svv.domain.domain import Domain
+from svv.domain import Domain
 
 mesh = pv.read('vessel.stl')
 domain = Domain(mesh)

--- a/docs/api/forest.html
+++ b/docs/api/forest.html
@@ -66,8 +66,8 @@
         <!-- Quick Example -->
         <div class="api-quick-example">
             <h2>Quick Example</h2>
-            <pre data-copy><code class="language-python">from svv.forest.forest import Forest
-from svv.domain.domain import Domain
+            <pre data-copy><code class="language-python">from svv.forest import Forest
+from svv.domain import Domain
 import numpy as np
 import pyvista as pv
 
@@ -441,8 +441,8 @@ forest.show(plot_domain=True)</code></pre>
 
                     <div class="api-example">
                         <h4>Save/Load Example</h4>
-                        <pre data-copy><code class="language-python">from svv.forest.forest import Forest
-from svv.domain.domain import Domain
+                        <pre data-copy><code class="language-python">from svv.forest import Forest
+from svv.domain import Domain
 import pyvista as pv
 
 # Create and grow a forest
@@ -486,8 +486,8 @@ loaded_forest.add(25)</code></pre>
 
                     <div class="api-example">
                         <h3>Arterial-Venous Network</h3>
-                        <pre data-copy><code class="language-python">from svv.forest.forest import Forest
-from svv.domain.domain import Domain
+                        <pre data-copy><code class="language-python">from svv.forest import Forest
+from svv.domain import Domain
 import numpy as np
 import pyvista as pv
 
@@ -531,7 +531,7 @@ forest.show(colors=['red', 'blue'], plot_domain=True)</code></pre>
 
                     <div class="api-example">
                         <h3>Multi-Tree Network with Connections</h3>
-                        <pre data-copy><code class="language-python">from svv.forest.forest import Forest
+                        <pre data-copy><code class="language-python">from svv.forest import Forest
 import numpy as np
 # Create forest with multiple trees per network
 forest = Forest(
@@ -573,7 +573,7 @@ for i in range(forest.n_networks):
                     <div class="api-example">
                         <h3>Competitive Growth Pattern</h3>
                         <pre data-copy><code class="language-python"># Enable competition between networks
-from svv.forest.forest import Forest
+from svv.forest import Forest
 import numpy as np
 forest = Forest(
     domain=domain,

--- a/docs/api/index_api.html
+++ b/docs/api/index_api.html
@@ -76,6 +76,19 @@
             </div>
         </div>
 
+        <section id="public-imports" class="api-section">
+            <h2>Public imports</h2>
+            <p>
+                The root package exposes the primary workflow classes, while public subpackages expose supporting
+                types. Calling <code>dir(svv)</code> reports the supported root namespace, and both import styles
+                resolve to the same class objects.
+            </p>
+            <pre data-copy><code class="language-python">import svv
+from svv import Domain, Forest, Simulation, Tree
+from svv.domain import Patch
+from svv.tree import TreeParameters, UnitSystem</code></pre>
+        </section>
+
         <!-- Quick Start Section
         <section id="quickstart" class="api-section">
             <h2>Quick Start</h2>
@@ -85,10 +98,10 @@
 
             <h3>Basic Import</h3>
             <pre data-copy><code class="language-python">import svv
-from svv.domain.domain import Domain
-from svv.forest.forest import Forest
-from svv.tree.tree import Tree
-from svv.simulation.simulation import Simulation
+from svv.domain import Domain
+from svv.forest import Forest
+from svv.tree import Tree
+from svv.simulation import Simulation
 
 # Create a domain
 domain = Domain()
@@ -190,7 +203,7 @@ results = sim.run()</code></pre>
                         </div>
                         <div class="api-example">
                             <h4>Example Usage</h4>
-                            <pre data-copy><code class="language-python">from svv.domain.domain import Domain
+                            <pre data-copy><code class="language-python">from svv.domain import Domain
 
 # Create a domain from a mesh
 import pyvista as pv
@@ -268,8 +281,8 @@ boundary, _ = domain.get_boundary(resolution=30)</code></pre>
                         <div class="api-example">
                             <h4>Example Usage</h4>
                             <pre data-copy><code class="language-python">import pyvista as pv
-from svv.domain.domain import Domain
-from svv.forest.forest import Forest
+from svv.domain import Domain
+from svv.forest import Forest
 
 # Prepare a domain and build its implicit representation
 domain = Domain(pv.Cube())
@@ -399,7 +412,7 @@ forest.export_solid(outdir='forest_model')</code></pre>
 
                         <div class="api-example">
                             <h4>Example Usage</h4>
-                            <pre data-copy><code class="language-python">from svv.simulation.simulation import Simulation
+                            <pre data-copy><code class="language-python">from svv.simulation import Simulation
 from svv.simulation.fluid.rom.zero_d.zerod_tree import export_0d_simulation
 
 # Wrap a generated tree in a Simulation container
@@ -490,8 +503,8 @@ plotter.screenshot('forest_viz.png')</code></pre>
                 <div class="api-example-card">
                     <h3>Generate a Vascular Tree</h3>
                     <pre data-copy><code class="language-python">import pyvista as pv
-from svv.domain.domain import Domain
-from svv.tree.tree import Tree
+from svv.domain import Domain
+from svv.tree import Tree
 
 domain = Domain(pv.Cube())
 domain.create()

--- a/docs/api/patch.html
+++ b/docs/api/patch.html
@@ -67,7 +67,7 @@
         <div class="api-quick-example">
             <h2>Quick Example</h2>
             <pre data-copy><code class="language-python">import numpy as np
-from svv.domain.patch import Patch
+from svv.domain import Patch
 
 # Create a patch with points and normals
 points = np.array([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]])
@@ -308,7 +308,7 @@ values = interpolation_func(test_points)</code></pre>
                     <div class="api-example">
                         <h3>Basic Patch Interpolation</h3>
                         <pre data-copy><code class="language-python">import numpy as np
-from svv.domain.patch import Patch
+from svv.domain import Patch
 
 # Create sample points on a sphere
 theta = np.linspace(0, np.pi, 10)

--- a/docs/api/simulation.html
+++ b/docs/api/simulation.html
@@ -68,7 +68,7 @@
         <!-- Quick Example -->
         <div class="api-quick-example">
             <h2>Quick Example</h2>
-            <pre data-copy><code class="language-python">from svv.simulation.simulation import Simulation
+            <pre data-copy><code class="language-python">from svv.simulation import Simulation
 # Assumes `tree` is an existing svv.tree.Tree built as in the Quickstart
 
 # Create simulation from tree
@@ -425,9 +425,9 @@ sim.construct_1d_fluid_simulation(
 
                     <div class="api-example">
                         <h3>Complete 3D CFD Simulation Setup</h3>
-                        <pre data-copy><code class="language-python">from svv.simulation.simulation import Simulation
-from svv.tree.tree import Tree
-from svv.domain.domain import Domain
+                        <pre data-copy><code class="language-python">from svv.simulation import Simulation
+from svv.tree import Tree
+from svv.domain import Domain
 import pyvista as pv
 
 # Generate vascular tree

--- a/docs/api/tree.html
+++ b/docs/api/tree.html
@@ -66,8 +66,8 @@
         <!-- Quick Example -->
         <div class="api-quick-example">
             <h2>Quick Example</h2>
-            <pre data-copy><code class="language-python">from svv.tree.tree import Tree
-from svv.domain.domain import Domain
+            <pre data-copy><code class="language-python">from svv.tree import Tree
+from svv.domain import Domain
 import pyvista as pv
 
 # Create domain from mesh
@@ -166,9 +166,9 @@ centerlines, polys = tree.export_centerlines()</code></pre>
 
                     <div class="api-example">
                         <h4>Constructor Examples</h4>
-                        <pre data-copy><code class="language-python">from svv.tree.tree import Tree
-from svv.tree.data.data import TreeParameters
-from svv.tree.data.units import UnitSystem
+                        <pre data-copy><code class="language-python">from svv.tree import Tree
+from svv.tree import TreeParameters
+from svv.tree import UnitSystem
 
 # Default tree (CGS units)
 tree = Tree()
@@ -427,8 +427,8 @@ tree_small = Tree(preallocation_step=10000)</code></pre>
 
                     <div class="api-example">
                         <h4>TreeParameters Examples</h4>
-                        <pre data-copy><code class="language-python">from svv.tree.data.data import TreeParameters
-from svv.tree.data.units import UnitSystem
+                        <pre data-copy><code class="language-python">from svv.tree import TreeParameters
+from svv.tree import UnitSystem
 
 # Create parameters with defaults
 params = TreeParameters()
@@ -633,8 +633,8 @@ params.set_unit_system(si_system, convert_existing=True)</code></pre>
 
                     <div class="api-example">
                         <h4>Save/Load Example</h4>
-                        <pre data-copy><code class="language-python">from svv.tree.tree import Tree
-from svv.domain.domain import Domain
+                        <pre data-copy><code class="language-python">from svv.tree import Tree
+from svv.domain import Domain
 import pyvista as pv
 
 # Create and grow a tree
@@ -696,8 +696,8 @@ loaded_tree.show()</code></pre>
 
                     <div class="api-example">
                         <h3>Basic Tree Generation</h3>
-                        <pre data-copy><code class="language-python">from svv.tree.tree import Tree
-from svv.domain.domain import Domain
+                        <pre data-copy><code class="language-python">from svv.tree import Tree
+from svv.domain import Domain
 import numpy as np
 import pyvista as pv
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -266,10 +266,13 @@ python -m pip install -e .[dev]</code></pre>
     <!-- VERIFY -->
     <section id="verify">
       <h2>Verifying the installation</h2>
-        <p>After installing svVascularize, verify the installation version by running the following
-            scripts in the Python interpreter.</p>
+        <p>After installing svVascularize, verify the version and public component imports by running
+            the following script in the Python interpreter.</p>
         <pre data-copy><code class="language-python">import svv
-print(svv.__version__)</code></pre>
+from svv import Domain, Forest, Simulation, Tree
+
+print(svv.__version__)
+print([name for name in ("Domain", "Forest", "Simulation", "Tree") if name in dir(svv)])</code></pre>
         <p>To test that individual components of the package are correctly installed and operational
         run the test suite associated with the module from the terminal or shell.</p>
       <pre data-copy><code class="language-shell">python -m svv.tests</code></pre>

--- a/docs/pipeline.html
+++ b/docs/pipeline.html
@@ -35,9 +35,9 @@
          which can be used to wrap around synthetic vascular objects in order to build simulation files. We will
          demonstrate the basic API below for a simple vascular tree. </p>
      <pre data-copy> <code class="language-python">import pyvista as pv
- from svv.domain.domain import Domain
- from svv.tree.tree import Tree
- from svv.simulation.simulation import Simulation
+ from svv.domain import Domain
+ from svv.tree import Tree
+ from svv.simulation import Simulation
 
  cube = Domain(pv.Cube())
  cube.create()

--- a/docs/quickstart.html
+++ b/docs/quickstart.html
@@ -33,8 +33,8 @@
 
     <h3>Generate and visualise a tree</h3>
     <pre data-copy><code class="language-python">import pyvista as pv
-from svv.domain.domain import Domain
-from svv.tree.tree import Tree
+from svv.domain import Domain
+from svv.tree import Tree
 
 # Creating the Tissue Domain
 cube = Domain(pv.Cube())
@@ -70,8 +70,8 @@ export_0d_simulation(t, outdir="my_tree_0d")
     with a desired number of inlets and outlets. These are especially useful for fabrication and fluid routing problems in which
       control over the start/end points are critical.</p>
         <pre data-copy><code class="language-python">import pyvista as pv
-from svv.domain.domain import Domain
-from svv.forest.forest import Forest
+from svv.domain import Domain
+from svv.forest import Forest
 
 # Creating the Tissue Domain
 cube = Domain(pv.Cube())

--- a/svv/__init__.py
+++ b/svv/__init__.py
@@ -1,35 +1,95 @@
+"""Public package facade and optional accelerator aliases for svVascularize."""
+
+import sys as _sys
+from importlib import import_module as _import_module
+
+
 __version__ = "0.0.50"
 
+__all__ = [
+    "__version__",
+    "domain",
+    "forest",
+    "simulation",
+    "tree",
+    "utils",
+    "visualize",
+    "Domain",
+    "Patch",
+    "Forest",
+    "Simulation",
+    "Tree",
+    "TreeParameters",
+    "UnitSystem",
+]
 
-# If the optional companion package with compiled accelerators is installed
-# (svv-accelerated), prefer those modules transparently by aliasing them into
-# svv.* import paths. This lets users simply `pip install svv[accel]` to get
-# faster implementations without changing imports in their code.
-try:
-    import importlib, sys
-    # Try importing the top-level companion namespace first.
-    importlib.import_module('svv_accel')
-    _ACCEL = {
-        'svv.domain.routines.c_allocate': 'svv_accel.domain.routines.c_allocate',
-        'svv.domain.routines.c_sample': 'svv_accel.domain.routines.c_sample',
-        'svv.utils.spatial.c_distance': 'svv_accel.utils.spatial.c_distance',
-        'svv.tree.utils.c_angle': 'svv_accel.tree.utils.c_angle',
-        'svv.tree.utils.c_basis': 'svv_accel.tree.utils.c_basis',
-        'svv.tree.utils.c_close': 'svv_accel.tree.utils.c_close',
-        'svv.tree.utils.c_local_optimize': 'svv_accel.tree.utils.c_local_optimize',
-        'svv.tree.utils.c_obb': 'svv_accel.tree.utils.c_obb',
-        'svv.tree.utils.c_update': 'svv_accel.tree.utils.c_update',
-        'svv.tree.utils.c_extend': 'svv_accel.tree.utils.c_extend',
-        'svv.simulation.utils.close_segments': 'svv_accel.simulation.utils.close_segments',
-        'svv.simulation.utils.extract': 'svv_accel.simulation.utils.extract',
-    }
-    for target, source in _ACCEL.items():
+
+# If the optional companion package with compiled accelerators is installed,
+# prefer those modules at the existing svv.* import paths.
+_ACCELERATOR_ALIASES = {
+    "svv.domain.routines.c_allocate": "svv_accel.domain.routines.c_allocate",
+    "svv.domain.routines.c_sample": "svv_accel.domain.routines.c_sample",
+    "svv.utils.spatial.c_distance": "svv_accel.utils.spatial.c_distance",
+    "svv.tree.utils.c_angle": "svv_accel.tree.utils.c_angle",
+    "svv.tree.utils.c_basis": "svv_accel.tree.utils.c_basis",
+    "svv.tree.utils.c_close": "svv_accel.tree.utils.c_close",
+    "svv.tree.utils.c_local_optimize": "svv_accel.tree.utils.c_local_optimize",
+    "svv.tree.utils.c_obb": "svv_accel.tree.utils.c_obb",
+    "svv.tree.utils.c_update": "svv_accel.tree.utils.c_update",
+    "svv.tree.utils.c_extend": "svv_accel.tree.utils.c_extend",
+    "svv.simulation.utils.close_segments": "svv_accel.simulation.utils.close_segments",
+    "svv.simulation.utils.extract": "svv_accel.simulation.utils.extract",
+}
+
+
+def _install_accelerator_aliases():
+    try:
+        _import_module("svv_accel")
+    except Exception:
+        return
+
+    for target, source in _ACCELERATOR_ALIASES.items():
         try:
-            mod = importlib.import_module(source)
-            sys.modules[target] = mod
+            _sys.modules[target] = _import_module(source)
         except Exception:
-            # If a specific accelerator module is missing, leave fallback in place
+            # A missing accelerator keeps the existing pure-Python fallback.
             pass
-except Exception:
-    # Companion package not installed; keep pure-Python fallbacks/compiled svv.* if present
-    pass
+
+
+_install_accelerator_aliases()
+del _install_accelerator_aliases
+
+
+_LAZY_EXPORTS = {
+    "domain": ("svv.domain", None),
+    "forest": ("svv.forest", None),
+    "simulation": ("svv.simulation", None),
+    "tree": ("svv.tree", None),
+    "utils": ("svv.utils", None),
+    "visualize": ("svv.visualize", None),
+    "Domain": ("svv.domain.domain", "Domain"),
+    "Patch": ("svv.domain.patch", "Patch"),
+    "Forest": ("svv.forest.forest", "Forest"),
+    "Simulation": ("svv.simulation.simulation", "Simulation"),
+    "Tree": ("svv.tree.tree", "Tree"),
+    "TreeParameters": ("svv.tree.data.data", "TreeParameters"),
+    "UnitSystem": ("svv.tree.data.units", "UnitSystem"),
+}
+
+
+def __getattr__(name):
+    try:
+        module_name, attribute_name = _LAZY_EXPORTS[name]
+    except KeyError:
+        raise AttributeError(
+            "module {!r} has no attribute {!r}".format(__name__, name)
+        ) from None
+
+    module = _import_module(module_name)
+    value = module if attribute_name is None else getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()).union(__all__))

--- a/svv/domain/__init__.py
+++ b/svv/domain/__init__.py
@@ -1,0 +1,29 @@
+"""Public domain API."""
+
+from importlib import import_module as _import_module
+
+
+__all__ = ["Domain", "Patch"]
+
+_LAZY_EXPORTS = {
+    "Domain": ("svv.domain.domain", "Domain"),
+    "Patch": ("svv.domain.patch", "Patch"),
+}
+
+
+def __getattr__(name):
+    try:
+        module_name, attribute_name = _LAZY_EXPORTS[name]
+    except KeyError:
+        raise AttributeError(
+            "module {!r} has no attribute {!r}".format(__name__, name)
+        ) from None
+
+    module = _import_module(module_name)
+    value = getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()).union(__all__))

--- a/svv/forest/__init__.py
+++ b/svv/forest/__init__.py
@@ -1,0 +1,28 @@
+"""Public vascular-forest API."""
+
+from importlib import import_module as _import_module
+
+
+__all__ = ["Forest"]
+
+_LAZY_EXPORTS = {
+    "Forest": ("svv.forest.forest", "Forest"),
+}
+
+
+def __getattr__(name):
+    try:
+        module_name, attribute_name = _LAZY_EXPORTS[name]
+    except KeyError:
+        raise AttributeError(
+            "module {!r} has no attribute {!r}".format(__name__, name)
+        ) from None
+
+    module = _import_module(module_name)
+    value = getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()).union(__all__))

--- a/svv/simulation/__init__.py
+++ b/svv/simulation/__init__.py
@@ -1,0 +1,28 @@
+"""Public simulation API."""
+
+from importlib import import_module as _import_module
+
+
+__all__ = ["Simulation"]
+
+_LAZY_EXPORTS = {
+    "Simulation": ("svv.simulation.simulation", "Simulation"),
+}
+
+
+def __getattr__(name):
+    try:
+        module_name, attribute_name = _LAZY_EXPORTS[name]
+    except KeyError:
+        raise AttributeError(
+            "module {!r} has no attribute {!r}".format(__name__, name)
+        ) from None
+
+    module = _import_module(module_name)
+    value = getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()).union(__all__))

--- a/svv/tree/__init__.py
+++ b/svv/tree/__init__.py
@@ -1,0 +1,30 @@
+"""Public vascular-tree API."""
+
+from importlib import import_module as _import_module
+
+
+__all__ = ["Tree", "TreeParameters", "UnitSystem"]
+
+_LAZY_EXPORTS = {
+    "Tree": ("svv.tree.tree", "Tree"),
+    "TreeParameters": ("svv.tree.data.data", "TreeParameters"),
+    "UnitSystem": ("svv.tree.data.units", "UnitSystem"),
+}
+
+
+def __getattr__(name):
+    try:
+        module_name, attribute_name = _LAZY_EXPORTS[name]
+    except KeyError:
+        raise AttributeError(
+            "module {!r} has no attribute {!r}".format(__name__, name)
+        ) from None
+
+    module = _import_module(module_name)
+    value = getattr(module, attribute_name)
+    globals()[name] = value
+    return value
+
+
+def __dir__():
+    return sorted(set(globals()).union(__all__))


### PR DESCRIPTION

<!-- Give your pull request (PR) a descriptive name -->

## Current situation

This change defines a curated, discoverable public API for the root `svv`
package and its principal subpackages. Public components resolve lazily, so a
clean `import svv` remains lightweight while `dir(svv)`, explicit convenience
imports, and wildcard imports expose a deliberate namespace.

The change also moves accelerator registration behind private names, preserves
existing deep import paths, updates the existing smoke workflow to consume the
public API, and documents the supported import forms.

Closes #99.

## Release Notes

- Defines an explicit root namespace for supported subpackages and high-level
  objects.
- Adds lazy, discoverable exports to the root package and principal
  subpackages.
- Keeps existing deep import paths compatible.
- Keeps accelerator bootstrap details outside the public namespace.
- Documents the supported root and subpackage imports.

### Public API contract

The root package exports exactly the following names, in this order:

```python
[
    "__version__",
    "domain",
    "forest",
    "simulation",
    "tree",
    "utils",
    "visualize",
    "Domain",
    "Patch",
    "Forest",
    "Simulation",
    "Tree",
    "TreeParameters",
    "UnitSystem",
]
```

The principal subpackages expose these explicit contracts:

| Package | Public exports |
|---|---|
| `svv.domain` | `Domain`, `Patch` |
| `svv.tree` | `Tree`, `TreeParameters`, `UnitSystem` |
| `svv.forest` | `Forest` |
| `svv.simulation` | `Simulation` |

Supported convenience imports include:

```python
import svv

from svv import Domain, Forest, Simulation, Tree
from svv.domain import Domain, Patch
from svv.tree import Tree, TreeParameters, UnitSystem
```

### Implementation details

- Adds explicit `__all__`, module-level `__getattr__`, and module-level
  `__dir__` implementations to the root package and principal subpackages.
- Resolves supported objects only when requested and caches successful
  resolutions in the corresponding module namespace.
- Leaves dependency and implementation import errors visible to callers.
- Keeps a clean root import from eagerly loading high-level implementation,
  PyVista, VTK, Qt, or GUI modules.
- Preserves the existing accelerator target mappings while keeping bootstrap
  helpers and loop variables private.
- Avoids dynamic filesystem scans and recursive public exports.
- Preserves `svv.__version__ == "0.0.50"`.

### Compatibility

Existing deep imports continue to resolve to the same class objects as the new
root and subpackage imports, including:

```python
from svv.domain.domain import Domain
from svv.domain.patch import Patch
from svv.forest.forest import Forest
from svv.simulation.simulation import Simulation
from svv.tree.tree import Tree
from svv.tree.data.data import TreeParameters
from svv.tree.data.units import UnitSystem
```

Deep utility imports also remain available without forcing their parent
packages to resolve high-level classes eagerly.

## Documentation

- Updates the existing basic smoke workflow to import `Domain`, `Forest`,
  `Simulation`, and `Tree` from the root package.
- Adds a basic public-import example to `README.md`.
- Adds a visible public-import section to the API overview.
- Updates high-level examples across the domain, patch, tree, forest,
  simulation, quick-start, pipeline, and installation pages.
- Retains specialized deep imports for components outside the curated public
  facade.

## Testing

Passed locally:

- Python 3.9 and Python 3.11 lightweight import and namespace checks.
- Exact root and subpackage `__all__` checks.
- `dir(svv)` discovery before lazy components are loaded.
- Root and subpackage wildcard-export checks.
- Lazy-resolution caching and unknown-attribute behavior.
- Root, subpackage, and deep-import object identity checks.
- Deep utility import checks.
- Base and accelerated wheel build, installation, and public API parity checks.
- `python -m compileall -q svv .github/scripts/basic_smoke_test.py`.
- `git diff --check upstream/main...HEAD`.


### Review checklist

- [x] Root and principal-subpackage public contracts are explicit.
- [x] Root imports remain lazy and discoverable.
- [x] Wildcard exports exclude bootstrap implementation details.
- [x] Existing deep imports remain compatible.
- [x] Base and accelerated installations expose the same public API locally.
- [x] Existing documentation identifies supported public imports.

## Code of Conduct & Contributing Guidelines

- [x] I agree to follow the [Code of Conduct](https://github.com/SimVascular/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/SimVascular/.github/blob/main/CONTRIBUTING.md).
